### PR TITLE
Add an extremely rough proof of concept wasm32 architecture – with running sigmoid

### DIFF
--- a/fearless_simd/examples/sigmoid.rs
+++ b/fearless_simd/examples/sigmoid.rs
@@ -20,5 +20,31 @@ fn main() {
     let inp = [0.1, -0.2, 0.001, 0.4, 1., 2., 3., 4.];
     let mut out = [0.; 8];
     sigmoid(level, &inp, &mut out);
-    println!("{out:?}");
+    js::log(&format!("{out:?}"));
+}
+
+
+// Some temporary WASM glue so I can run this in the browser and see the result.
+
+#[cfg(target_arch = "wasm32")]
+mod js {
+    #[link(wasm_import_module = "console")]
+    unsafe extern "C" {
+        #[link_name = "log"]
+        fn console_log_str(ptr: *const u8, len: usize);
+        
+    }
+    
+    pub fn log(s: &str) {
+        unsafe {
+            console_log_str(s.as_ptr(), s.len());
+        }
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+mod js {
+    pub fn log(s: &str) {
+        println!("{}", s);
+    }
 }

--- a/fearless_simd/src/generated.rs
+++ b/fearless_simd/src/generated.rs
@@ -7,11 +7,17 @@
 
 #[cfg(target_arch = "aarch64")]
 mod neon;
+#[cfg(target_arch = "wasm32")]
+mod wasm32;
+
 mod ops;
 mod simd_trait;
 mod simd_types;
 
 #[cfg(target_arch = "aarch64")]
 pub use neon::*;
+#[cfg(target_arch = "wasm32")]
+pub use wasm32::*;
+
 pub use simd_trait::*;
 pub use simd_types::*;

--- a/fearless_simd/src/lib.rs
+++ b/fearless_simd/src/lib.rs
@@ -23,6 +23,11 @@ pub mod aarch64;
 
 #[cfg(target_arch = "aarch64")]
 pub use aarch64::Level;
+#[cfg(target_arch = "wasm32")]
+pub mod wasm32;
+
+#[cfg(target_arch = "wasm32")]
+pub use wasm32::Level;
 
 #[cfg(all(target_arch = "aarch64", feature = "half"))]
 pub type f16 = half::f16;

--- a/fearless_simd/src/wasm32.rs
+++ b/fearless_simd/src/wasm32.rs
@@ -1,0 +1,54 @@
+// Copyright 2025 the Fearless_SIMD Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Support for WebAssembly SIMD capabilities.
+
+
+use crate::WithSimd;
+pub use crate::generated::WasmSimd128;
+
+/// A `Level` enum, which is maybe not required for compile time determined WASM.
+#[derive(Clone, Copy, Debug)]
+pub enum Level {
+    WasmSimd128(WasmSimd128),
+    // TODO: Fallback(Fallback),
+}
+
+impl Default for Level {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Level {
+    pub fn new() -> Self {
+        #[cfg(target_feature = "simd128")]
+        {
+            unsafe { Level::WasmSimd128(WasmSimd128::new_unchecked()) }
+        }
+        #[cfg(not(target_feature = "simd128"))]
+        {
+            // TODO: Return fallback level.
+            panic!("WASM SIMD128 not available. Compile with target-feature=+simd128");
+        }
+    }
+
+    #[inline]
+    pub fn as_wasm_simd128(self) -> Option<WasmSimd128> {
+        match self {
+            Level::WasmSimd128(simd128) => Some(simd128),
+        }
+    }
+
+    #[inline]
+    pub fn dispatch<W: WithSimd>(self, f: W) -> W::Output {
+        #[target_feature(enable = "simd128")]
+        #[inline]
+        fn dispatch_simd128<W: WithSimd>(f: W, simd128: WasmSimd128) -> W::Output {
+            f.with_simd(simd128)
+        }
+        match self {
+            Level::WasmSimd128(simd128) => dispatch_simd128(f, simd128),
+        }
+    }
+}

--- a/fearless_simd_gen/src/arch.rs
+++ b/fearless_simd_gen/src/arch.rs
@@ -96,3 +96,119 @@ pub fn split_intrinsic(name: &str, name2: &str, ty: &VecType) -> Ident {
         Span::call_site(),
     )
 }
+
+/// WASM SIMD 128
+
+pub struct WasmSimd128;
+
+impl Arch for WasmSimd128 {
+    fn arch_ty(&self, ty: &VecType) -> TokenStream {
+        // WASM SIMD128 uses v128 for all types
+        if ty.n_bits() == 128 {
+            quote! { v128 }
+        } else {
+            panic!("WASM SIMD128 only supports 128-bit vectors, got {}-bit", ty.n_bits());
+        }
+    }
+
+    fn expr(&self, op: &str, ty: &VecType, args: &[TokenStream]) -> TokenStream {
+        let intrinsic = wasm_intrinsic(op, ty);
+        quote! { #intrinsic ( #( #args ),* ) }
+    }
+}
+
+fn wasm_intrinsic(op: &str, ty: &VecType) -> Ident {
+    let type_suffix = match (ty.scalar, ty.scalar_bits, ty.len) {
+        (ScalarType::Float, 32, 4) => "f32x4",
+        (ScalarType::Int, 8, 16) => "i8x16",
+        (ScalarType::Int, 16, 8) => "i16x8",
+        (ScalarType::Int, 32, 4) => "i32x4",
+        (ScalarType::Int, 64, 2) => "i64x2",
+        (ScalarType::Unsigned, 8, 16) => "u8x16",
+        (ScalarType::Unsigned, 16, 8) => "u16x8",
+        (ScalarType::Unsigned, 32, 4) => "u32x4",
+        (ScalarType::Unsigned, 64, 2) => "u64x2",
+        (ScalarType::Mask, _, _) => {
+            // Masks use the same operations as their corresponding integer types
+            match ty.scalar_bits {
+                8 => "i8x16",
+                16 => "i16x8",
+                32 => "i32x4",
+                64 => "i64x2",
+                _ => panic!("Unsupported mask bit width: {}", ty.scalar_bits),
+            }
+        }
+        _ => panic!("Unsupported type for WASM SIMD: {:?}", ty),
+    };
+    
+    let op_name = match op {
+        "splat" => format!("{}_splat", type_suffix),
+        "abs" => {
+            match ty.scalar {
+                ScalarType::Float => format!("{}_abs", type_suffix),
+                ScalarType::Int => format!("{}_abs", type_suffix),
+                _ => panic!("abs not supported for {:?}", ty.scalar),
+            }
+        }
+        "neg" => {
+            match ty.scalar {
+                ScalarType::Float => format!("{}_neg", type_suffix),
+                ScalarType::Int => format!("{}_neg", type_suffix),
+                _ => panic!("neg not supported for {:?}", ty.scalar),
+            }
+        }
+        "sqrt" => {
+            if ty.scalar == ScalarType::Float {
+                format!("{}_sqrt", type_suffix)
+            } else {
+                panic!("sqrt only supported for float types")
+            }
+        }
+        "add" => format!("{}_add", type_suffix),
+        "sub" => format!("{}_sub", type_suffix),
+        "mul" => format!("{}_mul", type_suffix),
+        "div" => {
+            if ty.scalar == ScalarType::Float {
+                format!("{}_div", type_suffix)
+            } else {
+                panic!("div only supported for float types in WASM SIMD")
+            }
+        }
+        "simd_eq" => format!("{}_eq", type_suffix),
+        "simd_lt" => {
+            match ty.scalar {
+                ScalarType::Float | ScalarType::Int => format!("{}_lt", type_suffix),
+                ScalarType::Unsigned => format!("{}_lt", type_suffix),
+                _ => panic!("lt comparison not supported for {:?}", ty.scalar),
+            }
+        }
+        "simd_le" => {
+            match ty.scalar {
+                ScalarType::Float | ScalarType::Int => format!("{}_le", type_suffix),
+                ScalarType::Unsigned => format!("{}_le", type_suffix),
+                _ => panic!("le comparison not supported for {:?}", ty.scalar),
+            }
+        }
+        "simd_gt" => {
+            match ty.scalar {
+                ScalarType::Float | ScalarType::Int => format!("{}_gt", type_suffix),
+                ScalarType::Unsigned => format!("{}_gt", type_suffix),
+                _ => panic!("gt comparison not supported for {:?}", ty.scalar),
+            }
+        }
+        "simd_ge" => {
+            match ty.scalar {
+                ScalarType::Float | ScalarType::Int => format!("{}_ge", type_suffix),
+                ScalarType::Unsigned => format!("{}_ge", type_suffix),
+                _ => panic!("ge comparison not supported for {:?}", ty.scalar),
+            }
+        }
+        "and" => "v128_and".to_string(),
+        "or" => "v128_or".to_string(),
+        "xor" => "v128_xor".to_string(),
+        "not" => "v128_not".to_string(),
+        _ => panic!("Unsupported operation for WASM SIMD: {}", op),
+    };
+    
+    Ident::new(&op_name, Span::call_site())
+}

--- a/fearless_simd_gen/src/main.rs
+++ b/fearless_simd_gen/src/main.rs
@@ -12,6 +12,7 @@ mod mk_neon;
 mod mk_ops;
 mod mk_simd_trait;
 mod mk_simd_types;
+mod mk_wasm_simd128;
 mod ops;
 mod types;
 
@@ -21,6 +22,7 @@ enum Module {
     SimdTrait,
     Ops,
     Neon,
+    WasmSimd128
 }
 
 #[derive(Parser)]
@@ -36,6 +38,7 @@ impl Module {
             Module::SimdTrait => mk_simd_trait::mk_simd_trait(),
             Module::Ops => mk_ops::mk_ops(),
             Module::Neon => mk_neon::mk_neon_impl(mk_neon::Level::Neon),
+            Module::WasmSimd128 => mk_wasm_simd128::mk_wasm_simd128_impl(),
         }
     }
 
@@ -52,6 +55,7 @@ impl Module {
             Module::SimdTrait => "simd_trait",
             Module::Ops => "ops",
             Module::Neon => "neon",
+            Module::WasmSimd128 => "wasm_simd128",
         }
     }
 }
@@ -61,6 +65,7 @@ const MODULES: &[Module] = &[
     Module::SimdTrait,
     Module::Ops,
     Module::Neon,
+    Module::WasmSimd128
 ];
 
 const FILE_BASE: &str = "./fearless_simd/src/generated";

--- a/fearless_simd_gen/src/mk_wasm_simd128.rs
+++ b/fearless_simd_gen/src/mk_wasm_simd128.rs
@@ -1,0 +1,318 @@
+// Copyright 2025 the Fearless_SIMD Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use proc_macro2::{Span, TokenStream};
+use quote::quote;
+use syn::Ident;
+
+use crate::{
+    arch::{Arch, WasmSimd128},
+    generic::{generic_combine, generic_op, generic_split},
+    ops::{OpSig, ops_for_type},
+    types::{SIMD_TYPES, ScalarType, VecType, type_imports},
+};
+
+pub fn mk_wasm_simd128_impl() -> TokenStream {
+    let imports = type_imports();
+    let simd_impl = mk_simd_impl();
+    let ty_impl = mk_type_impl();
+
+    quote! {
+        use core::arch::wasm32::*;
+
+        use crate::{seal::Seal, Level, Simd, SimdFrom, SimdInto};
+
+        #imports
+
+        /// The SIMD token for WASM SIMD128.
+        #[derive(Clone, Copy, Debug)]
+        pub struct WasmSimd128 {
+            // No platform-specific handle needed for WASM
+        }
+
+        impl WasmSimd128 {
+            #[inline]
+            pub unsafe fn new_unchecked() -> Self {
+                WasmSimd128 {}
+            }
+        }
+
+        impl Seal for WasmSimd128 {}
+
+        #simd_impl
+
+        #ty_impl
+    }
+}
+
+fn mk_simd_impl() -> TokenStream {
+    let mut methods = vec![];
+
+    for vec_ty in SIMD_TYPES {
+        // Wasm simd only explicitly supports 128 bit intrinsics. We could create a synthetic 256
+        // bit target (that duplicates operations on low and high lanes. This should also be easily
+        // fused by v8).
+        if vec_ty.n_bits() != 128 {
+            // TODO: Is continue ok here?
+            continue;
+        }
+
+        let scalar_bits = vec_ty.scalar_bits;
+        let ty_name = vec_ty.rust_name();
+        let ty = vec_ty.rust();
+
+        for (method, sig) in ops_for_type(vec_ty) {
+            let method_name = format!("{method}_{ty_name}");
+            let method_ident = Ident::new(&method_name, Span::call_site());
+
+            let method = match sig {
+                OpSig::Splat => {
+                    let scalar = vec_ty.scalar.rust(scalar_bits);
+                    let expr = WasmSimd128.expr(method, vec_ty, &[quote! { val }]);
+                    quote! {
+                        #[inline(always)]
+                        fn #method_ident(self, val: #scalar) -> #ty<Self> {
+                            #expr.simd_into(self)
+                        }
+                    }
+                }
+                OpSig::Unary => {
+                    let args = [quote! { a.into() }];
+                    let expr = WasmSimd128.expr(method, vec_ty, &args);
+                    quote! {
+                        #[inline(always)]
+                        fn #method_ident(self, a: #ty<Self>) -> #ty<Self> {
+                            #expr.simd_into(self)
+                        }
+                    }
+                }
+                OpSig::Binary => {
+                    let args = [quote! { a.into() }, quote! { b.into() }];
+
+                    if method == "mul"
+                        && (vec_ty
+                            == (&VecType {
+                                scalar: ScalarType::Unsigned,
+                                scalar_bits: 8,
+                                len: 16,
+                            })
+                            || vec_ty
+                                == (&VecType {
+                                    scalar: ScalarType::Int,
+                                    scalar_bits: 8,
+                                    len: 16,
+                                }))
+                    {
+                        quote! {
+                            #[inline(always)]
+                            fn #method_ident(self, a: #ty<Self>, b: #ty<Self>) -> #ty<Self> {
+                                unsafe {
+                                    // WASM doesn't have `i8x16_mul` or `u8x16_mul`.
+                                    todo!();
+                                }
+                            }
+                        }
+                    } else if method == "copysign" {
+                        quote! {
+                            #[inline(always)]
+                            fn #method_ident(self, a: #ty<Self>, b: #ty<Self>) -> #ty<Self> {
+                                // Need to implement copysign.
+                                todo!();
+                            }
+                        }
+                    } else {
+                        let expr = WasmSimd128.expr(method, vec_ty, &args);
+                        quote! {
+                            #[inline(always)]
+                            fn #method_ident(self, a: #ty<Self>, b: #ty<Self>) -> #ty<Self> {
+                                #expr.simd_into(self)
+                            }
+                        }
+                    }
+                }
+                OpSig::Compare => {
+                    let args = [quote! { a.into() }, quote! { b.into() }];
+                    let expr = WasmSimd128.expr(method, vec_ty, &args);
+                    let ret_ty = vec_ty.mask_ty().rust();
+                    quote! {
+                        #[inline(always)]
+                        fn #method_ident(self, a: #ty<Self>, b: #ty<Self>) -> #ret_ty<Self> {
+                            #expr.simd_into(self)
+                        }
+                    }
+                }
+                OpSig::Select => {
+                    let mask_ty = vec_ty.mask_ty().rust();
+                    quote! {
+                        #[inline(always)]
+                        fn #method_ident(self, mask: #mask_ty<Self>, if_true: #ty<Self>, if_false: #ty<Self>) -> #ty<Self> {
+                            v128_bitselect(if_true.into(), if_false.into(), mask.into()).simd_into(self)
+                        }
+                    }
+                }
+                OpSig::Combine => generic_combine(vec_ty),
+                OpSig::Split => generic_split(vec_ty),
+                OpSig::Zip => {
+                    // Implement zip/unzip using WASM shuffle instructions
+                    match (vec_ty.scalar_bits, vec_ty.len) {
+                        (8, 16) => {
+                            // i8x16, u8x16, mask8x16
+                            let shuffle_lo = if method == "zip" {
+                                quote! { i8x16_shuffle::<0, 16, 1, 17, 2, 18, 3, 19, 4, 20, 5, 21, 6, 22, 7, 23> }
+                            } else {
+                                quote! { i8x16_shuffle::<0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30> }
+                            };
+                            let shuffle_hi = if method == "zip" {
+                                quote! { i8x16_shuffle::<8, 24, 9, 25, 10, 26, 11, 27, 12, 28, 13, 29, 14, 30, 15, 31> }
+                            } else {
+                                quote! { i8x16_shuffle::<1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 23, 25, 27, 29, 31> }
+                            };
+                            quote! {
+                                #[inline(always)]
+                                fn #method_ident(self, a: #ty<Self>, b: #ty<Self>) -> (#ty<Self>, #ty<Self>) {
+                                    let x = a.into();
+                                    let y = b.into();
+                                    (
+                                        #shuffle_lo(x, y).simd_into(self),
+                                        #shuffle_hi(x, y).simd_into(self),
+                                    )
+                                }
+                            }
+                        }
+                        (16, 8) => {
+                            // i16x8, u16x8, mask16x8
+                            let shuffle_lo = if method == "zip" {
+                                quote! { i16x8_shuffle::<0, 8, 1, 9, 2, 10, 3, 11> }
+                            } else {
+                                quote! { i16x8_shuffle::<0, 2, 4, 6, 8, 10, 12, 14> }
+                            };
+                            let shuffle_hi = if method == "zip" {
+                                quote! { i16x8_shuffle::<4, 12, 5, 13, 6, 14, 7, 15> }
+                            } else {
+                                quote! { i16x8_shuffle::<1, 3, 5, 7, 9, 11, 13, 15> }
+                            };
+                            quote! {
+                                #[inline(always)]
+                                fn #method_ident(self, a: #ty<Self>, b: #ty<Self>) -> (#ty<Self>, #ty<Self>) {
+                                    let x = a.into();
+                                    let y = b.into();
+                                    (
+                                        #shuffle_lo(x, y).simd_into(self),
+                                        #shuffle_hi(x, y).simd_into(self),
+                                    )
+                                }
+                            }
+                        }
+                        (32, 4) => {
+                            // f32x4, i32x4, u32x4, mask32x4
+                            let shuffle_lo = if method == "zip" {
+                                quote! { i32x4_shuffle::<0, 4, 1, 5> }
+                            } else {
+                                quote! { i32x4_shuffle::<0, 2, 4, 6> }
+                            };
+                            let shuffle_hi = if method == "zip" {
+                                quote! { i32x4_shuffle::<2, 6, 3, 7> }
+                            } else {
+                                quote! { i32x4_shuffle::<1, 3, 5, 7> }
+                            };
+                            quote! {
+                                #[inline(always)]
+                                fn #method_ident(self, a: #ty<Self>, b: #ty<Self>) -> (#ty<Self>, #ty<Self>) {
+                                    let x = a.into();
+                                    let y = b.into();
+                                    (
+                                        #shuffle_lo(x, y).simd_into(self),
+                                        #shuffle_hi(x, y).simd_into(self),
+                                    )
+                                }
+                            }
+                        }
+
+                        _ => {
+                            // Use generic implementation for other types (e.g., i64x2)
+                            continue;
+                        }
+                    }
+                }
+            };
+            methods.push(method);
+        }
+    }
+
+    for vec_ty in SIMD_TYPES {
+        if vec_ty.n_bits() != 256 {
+            continue;
+        }
+
+        for (method, sig) in ops_for_type(vec_ty) {
+            if method == "split" {
+                methods.push(generic_split(vec_ty));
+            } else if method != "combine" {
+                methods.push(generic_op(method, sig, vec_ty));
+            }
+        }
+    }
+
+    quote! {
+        impl Simd for WasmSimd128 {
+            type f32s = f32x4<Self>;
+            type u8s = u8x16<Self>;
+            type i8s = i8x16<Self>;
+            type u16s = u16x8<Self>;
+            type i16s = i16x8<Self>;
+            type u32s = u32x4<Self>;
+            type i32s = i32x4<Self>;
+            type mask8s = mask8x16<Self>;
+            type mask16s = mask16x8<Self>;
+            type mask32s = mask32x4<Self>;
+
+            #[inline(always)]
+            fn level(self) -> Level {
+                Level::WasmSimd128(self)
+            }
+
+            #[inline]
+            fn vectorize<F: FnOnce() -> R, R>(self, f: F) -> R {
+                #[target_feature(enable = "simd128")]
+                #[inline]
+                // unsafe not needed here with tf11, but can be justified
+                unsafe fn vectorize_simd128<F: FnOnce() -> R, R>(f: F) -> R {
+                    f()
+                }
+                unsafe { vectorize_simd128(f) }
+            }
+
+            #( #methods )*
+        }
+    }
+}
+
+fn mk_type_impl() -> TokenStream {
+    let mut result = vec![];
+    for ty in SIMD_TYPES {
+        if ty.n_bits() != 128 {
+            continue;
+        }
+        let simd = ty.rust();
+        result.push(quote! {
+            impl<S: Simd> SimdFrom<v128, S> for #simd<S> {
+                #[inline(always)]
+                fn simd_from(arch: v128, simd: S) -> Self {
+                    Self {
+                        val: unsafe { core::mem::transmute(arch) },
+                        simd
+                    }
+                }
+            }
+            impl<S: Simd> From<#simd<S>> for v128 {
+                #[inline(always)]
+                fn from(value: #simd<S>) -> Self {
+                    unsafe { core::mem::transmute(value.val) }
+                }
+            }
+        })
+    }
+    quote! {
+        #( #result )*
+    }
+}


### PR DESCRIPTION
This is a super rough POC for adding a wasm32 target architecture SIMD generated file.

While neon has ~4000 intrinsics, simd128 has ~400!
This implementation compiles, and the sigmoid example returns correct results when run via WASM. I'm not convinced any SIMD is being used yet though.

Steps I've been using to test:

Generate the `wasm32.rs` file (checked into this PR):
`cargo run -- -m wasm-simd128 > ./fearless_simd/src/generated/wasm32.rs`

I modified the sigmoid example so it uses the browser's `console.log` (also in this draft PR), and compiled with: `RUSTFLAGS="-C target-feature=+simd128" cargo build --target wasm32-unknown-unknown --release --example sigmoid`.


Using `wasm2wat` I confirmed simd intrinsic usage, except it was very minimal - so I am suspicious that something is wrong here.

I created a base64 string of the wasm with: `cat ./target/wasm32-unknown-unknown/release/examples/sigmoid.wasm | base64`, and put it on jsbin:

Live example: https://jsbin.com/cicagusime/edit?html,console,output

