### PR TITLE
Add initial WASM SIMD128 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,8 +53,6 @@ jobs:
   build-no-std:
     name: build (no_std)
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,33 @@ jobs:
 
       - name: cargo test
         run: cargo test run --workspace --locked --all-features --no-fail-fast
-    
+
+  test-stable-wasm:
+    name: test (wasm32)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: install stable toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUST_STABLE_VER }}
+          targets: wasm32-unknown-unknown
+
+      - name: restore cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.event_name != 'merge_group' }}
+
+      - name: install wasm-pack
+        uses: taiki-e/install-action@v2
+        with:
+          tool: wasm-pack
+
+      - name: Run fearless_simd_tests on Chrome
+        run: wasm-pack test --headless --chrome
+        working-directory: fearless_simd_tests
+  
   build-no-std:
     name: build (no_std)
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,6 +53,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793db76d6187cd04dff33004d8e6c9cc4e05cd330500379d2394209271b4aeee"
+
+[[package]]
+name = "cc"
+version = "1.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d487aa071b5f64da6f19a3e848e3578944b726ee5a4854b82172f02aa876bfdc"
+dependencies = [
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -130,6 +145,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fearless_simd_tests"
+version = "0.0.0"
+dependencies = [
+ "fearless_simd",
+ "wasm-bindgen",
+ "wasm-bindgen-test",
+]
+
+[[package]]
 name = "half"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -152,10 +176,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
+name = "js-sys"
+version = "0.3.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "libm"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
+
+[[package]]
+name = "log"
+version = "0.4.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+
+[[package]]
+name = "minicov"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f27fe9f1cc3c22e1687f9446c2083c4c5fc7f0bcf1c7a86bdbded14985895b4b"
+dependencies = [
+ "cc",
+ "walkdir",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -192,6 +248,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -219,6 +296,130 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
+dependencies = [
+ "bumpalo",
+ "log",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "wasm-bindgen-test"
+version = "0.3.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66c8d5e33ca3b6d9fa3b4676d774c5778031d27a578c2b007f905acf816152c3"
+dependencies = [
+ "js-sys",
+ "minicov",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-bindgen-test-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-test-macro"
+version = "0.3.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17d5042cc5fa009658f9a7333ef24291b1291a25b6382dd68862a7f3b969f69b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+dependencies = [
+ "windows-sys",
+]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,10 @@
 [workspace]
 resolver = "2"
-members = ["fearless_simd", "fearless_simd_gen"]
+members = ["fearless_simd", "fearless_simd_gen", "fearless_simd_tests"]
 
 [workspace.package]
 license = "MIT/Apache-2.0"
 edition = "2024"
+
+[workspace.dependencies]
+fearless_simd = { path = "fearless_simd" }

--- a/fearless_simd/src/generated.rs
+++ b/fearless_simd/src/generated.rs
@@ -7,6 +7,8 @@
 
 #[cfg(all(feature = "std", target_arch = "aarch64"))]
 mod neon;
+#[cfg(target_arch = "wasm32")]
+mod wasm;
 mod fallback;
 mod ops;
 mod simd_trait;
@@ -14,6 +16,8 @@ mod simd_types;
 
 #[cfg(all(feature = "std", target_arch = "aarch64"))]
 pub use neon::*;
+#[cfg(target_arch = "wasm32")]
+pub use wasm::*;
 pub use fallback::*;
 pub use simd_trait::*;
 pub use simd_types::*;

--- a/fearless_simd/src/generated/fallback.rs
+++ b/fearless_simd/src/generated/fallback.rs
@@ -142,50 +142,50 @@ impl Simd for Fallback {
     #[inline(always)]
     fn simd_eq_f32x4(self, a: f32x4<Self>, b: f32x4<Self>) -> mask32x4<Self> {
         [
-            f32::eq(&a[0usize], &b[0usize]) as i32,
-            f32::eq(&a[1usize], &b[1usize]) as i32,
-            f32::eq(&a[2usize], &b[2usize]) as i32,
-            f32::eq(&a[3usize], &b[3usize]) as i32,
+            -(f32::eq(&a[0usize], &b[0usize]) as i32),
+            -(f32::eq(&a[1usize], &b[1usize]) as i32),
+            -(f32::eq(&a[2usize], &b[2usize]) as i32),
+            -(f32::eq(&a[3usize], &b[3usize]) as i32),
         ]
             .simd_into(self)
     }
     #[inline(always)]
     fn simd_lt_f32x4(self, a: f32x4<Self>, b: f32x4<Self>) -> mask32x4<Self> {
         [
-            f32::lt(&a[0usize], &b[0usize]) as i32,
-            f32::lt(&a[1usize], &b[1usize]) as i32,
-            f32::lt(&a[2usize], &b[2usize]) as i32,
-            f32::lt(&a[3usize], &b[3usize]) as i32,
+            -(f32::lt(&a[0usize], &b[0usize]) as i32),
+            -(f32::lt(&a[1usize], &b[1usize]) as i32),
+            -(f32::lt(&a[2usize], &b[2usize]) as i32),
+            -(f32::lt(&a[3usize], &b[3usize]) as i32),
         ]
             .simd_into(self)
     }
     #[inline(always)]
     fn simd_le_f32x4(self, a: f32x4<Self>, b: f32x4<Self>) -> mask32x4<Self> {
         [
-            f32::le(&a[0usize], &b[0usize]) as i32,
-            f32::le(&a[1usize], &b[1usize]) as i32,
-            f32::le(&a[2usize], &b[2usize]) as i32,
-            f32::le(&a[3usize], &b[3usize]) as i32,
+            -(f32::le(&a[0usize], &b[0usize]) as i32),
+            -(f32::le(&a[1usize], &b[1usize]) as i32),
+            -(f32::le(&a[2usize], &b[2usize]) as i32),
+            -(f32::le(&a[3usize], &b[3usize]) as i32),
         ]
             .simd_into(self)
     }
     #[inline(always)]
     fn simd_ge_f32x4(self, a: f32x4<Self>, b: f32x4<Self>) -> mask32x4<Self> {
         [
-            f32::ge(&a[0usize], &b[0usize]) as i32,
-            f32::ge(&a[1usize], &b[1usize]) as i32,
-            f32::ge(&a[2usize], &b[2usize]) as i32,
-            f32::ge(&a[3usize], &b[3usize]) as i32,
+            -(f32::ge(&a[0usize], &b[0usize]) as i32),
+            -(f32::ge(&a[1usize], &b[1usize]) as i32),
+            -(f32::ge(&a[2usize], &b[2usize]) as i32),
+            -(f32::ge(&a[3usize], &b[3usize]) as i32),
         ]
             .simd_into(self)
     }
     #[inline(always)]
     fn simd_gt_f32x4(self, a: f32x4<Self>, b: f32x4<Self>) -> mask32x4<Self> {
         [
-            f32::gt(&a[0usize], &b[0usize]) as i32,
-            f32::gt(&a[1usize], &b[1usize]) as i32,
-            f32::gt(&a[2usize], &b[2usize]) as i32,
-            f32::gt(&a[3usize], &b[3usize]) as i32,
+            -(f32::gt(&a[0usize], &b[0usize]) as i32),
+            -(f32::gt(&a[1usize], &b[1usize]) as i32),
+            -(f32::gt(&a[2usize], &b[2usize]) as i32),
+            -(f32::gt(&a[3usize], &b[3usize]) as i32),
         ]
             .simd_into(self)
     }
@@ -446,110 +446,110 @@ impl Simd for Fallback {
     #[inline(always)]
     fn simd_eq_i8x16(self, a: i8x16<Self>, b: i8x16<Self>) -> mask8x16<Self> {
         [
-            i8::eq(&a[0usize], &b[0usize]) as i8,
-            i8::eq(&a[1usize], &b[1usize]) as i8,
-            i8::eq(&a[2usize], &b[2usize]) as i8,
-            i8::eq(&a[3usize], &b[3usize]) as i8,
-            i8::eq(&a[4usize], &b[4usize]) as i8,
-            i8::eq(&a[5usize], &b[5usize]) as i8,
-            i8::eq(&a[6usize], &b[6usize]) as i8,
-            i8::eq(&a[7usize], &b[7usize]) as i8,
-            i8::eq(&a[8usize], &b[8usize]) as i8,
-            i8::eq(&a[9usize], &b[9usize]) as i8,
-            i8::eq(&a[10usize], &b[10usize]) as i8,
-            i8::eq(&a[11usize], &b[11usize]) as i8,
-            i8::eq(&a[12usize], &b[12usize]) as i8,
-            i8::eq(&a[13usize], &b[13usize]) as i8,
-            i8::eq(&a[14usize], &b[14usize]) as i8,
-            i8::eq(&a[15usize], &b[15usize]) as i8,
+            -(i8::eq(&a[0usize], &b[0usize]) as i8),
+            -(i8::eq(&a[1usize], &b[1usize]) as i8),
+            -(i8::eq(&a[2usize], &b[2usize]) as i8),
+            -(i8::eq(&a[3usize], &b[3usize]) as i8),
+            -(i8::eq(&a[4usize], &b[4usize]) as i8),
+            -(i8::eq(&a[5usize], &b[5usize]) as i8),
+            -(i8::eq(&a[6usize], &b[6usize]) as i8),
+            -(i8::eq(&a[7usize], &b[7usize]) as i8),
+            -(i8::eq(&a[8usize], &b[8usize]) as i8),
+            -(i8::eq(&a[9usize], &b[9usize]) as i8),
+            -(i8::eq(&a[10usize], &b[10usize]) as i8),
+            -(i8::eq(&a[11usize], &b[11usize]) as i8),
+            -(i8::eq(&a[12usize], &b[12usize]) as i8),
+            -(i8::eq(&a[13usize], &b[13usize]) as i8),
+            -(i8::eq(&a[14usize], &b[14usize]) as i8),
+            -(i8::eq(&a[15usize], &b[15usize]) as i8),
         ]
             .simd_into(self)
     }
     #[inline(always)]
     fn simd_lt_i8x16(self, a: i8x16<Self>, b: i8x16<Self>) -> mask8x16<Self> {
         [
-            i8::lt(&a[0usize], &b[0usize]) as i8,
-            i8::lt(&a[1usize], &b[1usize]) as i8,
-            i8::lt(&a[2usize], &b[2usize]) as i8,
-            i8::lt(&a[3usize], &b[3usize]) as i8,
-            i8::lt(&a[4usize], &b[4usize]) as i8,
-            i8::lt(&a[5usize], &b[5usize]) as i8,
-            i8::lt(&a[6usize], &b[6usize]) as i8,
-            i8::lt(&a[7usize], &b[7usize]) as i8,
-            i8::lt(&a[8usize], &b[8usize]) as i8,
-            i8::lt(&a[9usize], &b[9usize]) as i8,
-            i8::lt(&a[10usize], &b[10usize]) as i8,
-            i8::lt(&a[11usize], &b[11usize]) as i8,
-            i8::lt(&a[12usize], &b[12usize]) as i8,
-            i8::lt(&a[13usize], &b[13usize]) as i8,
-            i8::lt(&a[14usize], &b[14usize]) as i8,
-            i8::lt(&a[15usize], &b[15usize]) as i8,
+            -(i8::lt(&a[0usize], &b[0usize]) as i8),
+            -(i8::lt(&a[1usize], &b[1usize]) as i8),
+            -(i8::lt(&a[2usize], &b[2usize]) as i8),
+            -(i8::lt(&a[3usize], &b[3usize]) as i8),
+            -(i8::lt(&a[4usize], &b[4usize]) as i8),
+            -(i8::lt(&a[5usize], &b[5usize]) as i8),
+            -(i8::lt(&a[6usize], &b[6usize]) as i8),
+            -(i8::lt(&a[7usize], &b[7usize]) as i8),
+            -(i8::lt(&a[8usize], &b[8usize]) as i8),
+            -(i8::lt(&a[9usize], &b[9usize]) as i8),
+            -(i8::lt(&a[10usize], &b[10usize]) as i8),
+            -(i8::lt(&a[11usize], &b[11usize]) as i8),
+            -(i8::lt(&a[12usize], &b[12usize]) as i8),
+            -(i8::lt(&a[13usize], &b[13usize]) as i8),
+            -(i8::lt(&a[14usize], &b[14usize]) as i8),
+            -(i8::lt(&a[15usize], &b[15usize]) as i8),
         ]
             .simd_into(self)
     }
     #[inline(always)]
     fn simd_le_i8x16(self, a: i8x16<Self>, b: i8x16<Self>) -> mask8x16<Self> {
         [
-            i8::le(&a[0usize], &b[0usize]) as i8,
-            i8::le(&a[1usize], &b[1usize]) as i8,
-            i8::le(&a[2usize], &b[2usize]) as i8,
-            i8::le(&a[3usize], &b[3usize]) as i8,
-            i8::le(&a[4usize], &b[4usize]) as i8,
-            i8::le(&a[5usize], &b[5usize]) as i8,
-            i8::le(&a[6usize], &b[6usize]) as i8,
-            i8::le(&a[7usize], &b[7usize]) as i8,
-            i8::le(&a[8usize], &b[8usize]) as i8,
-            i8::le(&a[9usize], &b[9usize]) as i8,
-            i8::le(&a[10usize], &b[10usize]) as i8,
-            i8::le(&a[11usize], &b[11usize]) as i8,
-            i8::le(&a[12usize], &b[12usize]) as i8,
-            i8::le(&a[13usize], &b[13usize]) as i8,
-            i8::le(&a[14usize], &b[14usize]) as i8,
-            i8::le(&a[15usize], &b[15usize]) as i8,
+            -(i8::le(&a[0usize], &b[0usize]) as i8),
+            -(i8::le(&a[1usize], &b[1usize]) as i8),
+            -(i8::le(&a[2usize], &b[2usize]) as i8),
+            -(i8::le(&a[3usize], &b[3usize]) as i8),
+            -(i8::le(&a[4usize], &b[4usize]) as i8),
+            -(i8::le(&a[5usize], &b[5usize]) as i8),
+            -(i8::le(&a[6usize], &b[6usize]) as i8),
+            -(i8::le(&a[7usize], &b[7usize]) as i8),
+            -(i8::le(&a[8usize], &b[8usize]) as i8),
+            -(i8::le(&a[9usize], &b[9usize]) as i8),
+            -(i8::le(&a[10usize], &b[10usize]) as i8),
+            -(i8::le(&a[11usize], &b[11usize]) as i8),
+            -(i8::le(&a[12usize], &b[12usize]) as i8),
+            -(i8::le(&a[13usize], &b[13usize]) as i8),
+            -(i8::le(&a[14usize], &b[14usize]) as i8),
+            -(i8::le(&a[15usize], &b[15usize]) as i8),
         ]
             .simd_into(self)
     }
     #[inline(always)]
     fn simd_ge_i8x16(self, a: i8x16<Self>, b: i8x16<Self>) -> mask8x16<Self> {
         [
-            i8::ge(&a[0usize], &b[0usize]) as i8,
-            i8::ge(&a[1usize], &b[1usize]) as i8,
-            i8::ge(&a[2usize], &b[2usize]) as i8,
-            i8::ge(&a[3usize], &b[3usize]) as i8,
-            i8::ge(&a[4usize], &b[4usize]) as i8,
-            i8::ge(&a[5usize], &b[5usize]) as i8,
-            i8::ge(&a[6usize], &b[6usize]) as i8,
-            i8::ge(&a[7usize], &b[7usize]) as i8,
-            i8::ge(&a[8usize], &b[8usize]) as i8,
-            i8::ge(&a[9usize], &b[9usize]) as i8,
-            i8::ge(&a[10usize], &b[10usize]) as i8,
-            i8::ge(&a[11usize], &b[11usize]) as i8,
-            i8::ge(&a[12usize], &b[12usize]) as i8,
-            i8::ge(&a[13usize], &b[13usize]) as i8,
-            i8::ge(&a[14usize], &b[14usize]) as i8,
-            i8::ge(&a[15usize], &b[15usize]) as i8,
+            -(i8::ge(&a[0usize], &b[0usize]) as i8),
+            -(i8::ge(&a[1usize], &b[1usize]) as i8),
+            -(i8::ge(&a[2usize], &b[2usize]) as i8),
+            -(i8::ge(&a[3usize], &b[3usize]) as i8),
+            -(i8::ge(&a[4usize], &b[4usize]) as i8),
+            -(i8::ge(&a[5usize], &b[5usize]) as i8),
+            -(i8::ge(&a[6usize], &b[6usize]) as i8),
+            -(i8::ge(&a[7usize], &b[7usize]) as i8),
+            -(i8::ge(&a[8usize], &b[8usize]) as i8),
+            -(i8::ge(&a[9usize], &b[9usize]) as i8),
+            -(i8::ge(&a[10usize], &b[10usize]) as i8),
+            -(i8::ge(&a[11usize], &b[11usize]) as i8),
+            -(i8::ge(&a[12usize], &b[12usize]) as i8),
+            -(i8::ge(&a[13usize], &b[13usize]) as i8),
+            -(i8::ge(&a[14usize], &b[14usize]) as i8),
+            -(i8::ge(&a[15usize], &b[15usize]) as i8),
         ]
             .simd_into(self)
     }
     #[inline(always)]
     fn simd_gt_i8x16(self, a: i8x16<Self>, b: i8x16<Self>) -> mask8x16<Self> {
         [
-            i8::gt(&a[0usize], &b[0usize]) as i8,
-            i8::gt(&a[1usize], &b[1usize]) as i8,
-            i8::gt(&a[2usize], &b[2usize]) as i8,
-            i8::gt(&a[3usize], &b[3usize]) as i8,
-            i8::gt(&a[4usize], &b[4usize]) as i8,
-            i8::gt(&a[5usize], &b[5usize]) as i8,
-            i8::gt(&a[6usize], &b[6usize]) as i8,
-            i8::gt(&a[7usize], &b[7usize]) as i8,
-            i8::gt(&a[8usize], &b[8usize]) as i8,
-            i8::gt(&a[9usize], &b[9usize]) as i8,
-            i8::gt(&a[10usize], &b[10usize]) as i8,
-            i8::gt(&a[11usize], &b[11usize]) as i8,
-            i8::gt(&a[12usize], &b[12usize]) as i8,
-            i8::gt(&a[13usize], &b[13usize]) as i8,
-            i8::gt(&a[14usize], &b[14usize]) as i8,
-            i8::gt(&a[15usize], &b[15usize]) as i8,
+            -(i8::gt(&a[0usize], &b[0usize]) as i8),
+            -(i8::gt(&a[1usize], &b[1usize]) as i8),
+            -(i8::gt(&a[2usize], &b[2usize]) as i8),
+            -(i8::gt(&a[3usize], &b[3usize]) as i8),
+            -(i8::gt(&a[4usize], &b[4usize]) as i8),
+            -(i8::gt(&a[5usize], &b[5usize]) as i8),
+            -(i8::gt(&a[6usize], &b[6usize]) as i8),
+            -(i8::gt(&a[7usize], &b[7usize]) as i8),
+            -(i8::gt(&a[8usize], &b[8usize]) as i8),
+            -(i8::gt(&a[9usize], &b[9usize]) as i8),
+            -(i8::gt(&a[10usize], &b[10usize]) as i8),
+            -(i8::gt(&a[11usize], &b[11usize]) as i8),
+            -(i8::gt(&a[12usize], &b[12usize]) as i8),
+            -(i8::gt(&a[13usize], &b[13usize]) as i8),
+            -(i8::gt(&a[14usize], &b[14usize]) as i8),
+            -(i8::gt(&a[15usize], &b[15usize]) as i8),
         ]
             .simd_into(self)
     }
@@ -834,110 +834,110 @@ impl Simd for Fallback {
     #[inline(always)]
     fn simd_eq_u8x16(self, a: u8x16<Self>, b: u8x16<Self>) -> mask8x16<Self> {
         [
-            u8::eq(&a[0usize], &b[0usize]) as i8,
-            u8::eq(&a[1usize], &b[1usize]) as i8,
-            u8::eq(&a[2usize], &b[2usize]) as i8,
-            u8::eq(&a[3usize], &b[3usize]) as i8,
-            u8::eq(&a[4usize], &b[4usize]) as i8,
-            u8::eq(&a[5usize], &b[5usize]) as i8,
-            u8::eq(&a[6usize], &b[6usize]) as i8,
-            u8::eq(&a[7usize], &b[7usize]) as i8,
-            u8::eq(&a[8usize], &b[8usize]) as i8,
-            u8::eq(&a[9usize], &b[9usize]) as i8,
-            u8::eq(&a[10usize], &b[10usize]) as i8,
-            u8::eq(&a[11usize], &b[11usize]) as i8,
-            u8::eq(&a[12usize], &b[12usize]) as i8,
-            u8::eq(&a[13usize], &b[13usize]) as i8,
-            u8::eq(&a[14usize], &b[14usize]) as i8,
-            u8::eq(&a[15usize], &b[15usize]) as i8,
+            -(u8::eq(&a[0usize], &b[0usize]) as i8),
+            -(u8::eq(&a[1usize], &b[1usize]) as i8),
+            -(u8::eq(&a[2usize], &b[2usize]) as i8),
+            -(u8::eq(&a[3usize], &b[3usize]) as i8),
+            -(u8::eq(&a[4usize], &b[4usize]) as i8),
+            -(u8::eq(&a[5usize], &b[5usize]) as i8),
+            -(u8::eq(&a[6usize], &b[6usize]) as i8),
+            -(u8::eq(&a[7usize], &b[7usize]) as i8),
+            -(u8::eq(&a[8usize], &b[8usize]) as i8),
+            -(u8::eq(&a[9usize], &b[9usize]) as i8),
+            -(u8::eq(&a[10usize], &b[10usize]) as i8),
+            -(u8::eq(&a[11usize], &b[11usize]) as i8),
+            -(u8::eq(&a[12usize], &b[12usize]) as i8),
+            -(u8::eq(&a[13usize], &b[13usize]) as i8),
+            -(u8::eq(&a[14usize], &b[14usize]) as i8),
+            -(u8::eq(&a[15usize], &b[15usize]) as i8),
         ]
             .simd_into(self)
     }
     #[inline(always)]
     fn simd_lt_u8x16(self, a: u8x16<Self>, b: u8x16<Self>) -> mask8x16<Self> {
         [
-            u8::lt(&a[0usize], &b[0usize]) as i8,
-            u8::lt(&a[1usize], &b[1usize]) as i8,
-            u8::lt(&a[2usize], &b[2usize]) as i8,
-            u8::lt(&a[3usize], &b[3usize]) as i8,
-            u8::lt(&a[4usize], &b[4usize]) as i8,
-            u8::lt(&a[5usize], &b[5usize]) as i8,
-            u8::lt(&a[6usize], &b[6usize]) as i8,
-            u8::lt(&a[7usize], &b[7usize]) as i8,
-            u8::lt(&a[8usize], &b[8usize]) as i8,
-            u8::lt(&a[9usize], &b[9usize]) as i8,
-            u8::lt(&a[10usize], &b[10usize]) as i8,
-            u8::lt(&a[11usize], &b[11usize]) as i8,
-            u8::lt(&a[12usize], &b[12usize]) as i8,
-            u8::lt(&a[13usize], &b[13usize]) as i8,
-            u8::lt(&a[14usize], &b[14usize]) as i8,
-            u8::lt(&a[15usize], &b[15usize]) as i8,
+            -(u8::lt(&a[0usize], &b[0usize]) as i8),
+            -(u8::lt(&a[1usize], &b[1usize]) as i8),
+            -(u8::lt(&a[2usize], &b[2usize]) as i8),
+            -(u8::lt(&a[3usize], &b[3usize]) as i8),
+            -(u8::lt(&a[4usize], &b[4usize]) as i8),
+            -(u8::lt(&a[5usize], &b[5usize]) as i8),
+            -(u8::lt(&a[6usize], &b[6usize]) as i8),
+            -(u8::lt(&a[7usize], &b[7usize]) as i8),
+            -(u8::lt(&a[8usize], &b[8usize]) as i8),
+            -(u8::lt(&a[9usize], &b[9usize]) as i8),
+            -(u8::lt(&a[10usize], &b[10usize]) as i8),
+            -(u8::lt(&a[11usize], &b[11usize]) as i8),
+            -(u8::lt(&a[12usize], &b[12usize]) as i8),
+            -(u8::lt(&a[13usize], &b[13usize]) as i8),
+            -(u8::lt(&a[14usize], &b[14usize]) as i8),
+            -(u8::lt(&a[15usize], &b[15usize]) as i8),
         ]
             .simd_into(self)
     }
     #[inline(always)]
     fn simd_le_u8x16(self, a: u8x16<Self>, b: u8x16<Self>) -> mask8x16<Self> {
         [
-            u8::le(&a[0usize], &b[0usize]) as i8,
-            u8::le(&a[1usize], &b[1usize]) as i8,
-            u8::le(&a[2usize], &b[2usize]) as i8,
-            u8::le(&a[3usize], &b[3usize]) as i8,
-            u8::le(&a[4usize], &b[4usize]) as i8,
-            u8::le(&a[5usize], &b[5usize]) as i8,
-            u8::le(&a[6usize], &b[6usize]) as i8,
-            u8::le(&a[7usize], &b[7usize]) as i8,
-            u8::le(&a[8usize], &b[8usize]) as i8,
-            u8::le(&a[9usize], &b[9usize]) as i8,
-            u8::le(&a[10usize], &b[10usize]) as i8,
-            u8::le(&a[11usize], &b[11usize]) as i8,
-            u8::le(&a[12usize], &b[12usize]) as i8,
-            u8::le(&a[13usize], &b[13usize]) as i8,
-            u8::le(&a[14usize], &b[14usize]) as i8,
-            u8::le(&a[15usize], &b[15usize]) as i8,
+            -(u8::le(&a[0usize], &b[0usize]) as i8),
+            -(u8::le(&a[1usize], &b[1usize]) as i8),
+            -(u8::le(&a[2usize], &b[2usize]) as i8),
+            -(u8::le(&a[3usize], &b[3usize]) as i8),
+            -(u8::le(&a[4usize], &b[4usize]) as i8),
+            -(u8::le(&a[5usize], &b[5usize]) as i8),
+            -(u8::le(&a[6usize], &b[6usize]) as i8),
+            -(u8::le(&a[7usize], &b[7usize]) as i8),
+            -(u8::le(&a[8usize], &b[8usize]) as i8),
+            -(u8::le(&a[9usize], &b[9usize]) as i8),
+            -(u8::le(&a[10usize], &b[10usize]) as i8),
+            -(u8::le(&a[11usize], &b[11usize]) as i8),
+            -(u8::le(&a[12usize], &b[12usize]) as i8),
+            -(u8::le(&a[13usize], &b[13usize]) as i8),
+            -(u8::le(&a[14usize], &b[14usize]) as i8),
+            -(u8::le(&a[15usize], &b[15usize]) as i8),
         ]
             .simd_into(self)
     }
     #[inline(always)]
     fn simd_ge_u8x16(self, a: u8x16<Self>, b: u8x16<Self>) -> mask8x16<Self> {
         [
-            u8::ge(&a[0usize], &b[0usize]) as i8,
-            u8::ge(&a[1usize], &b[1usize]) as i8,
-            u8::ge(&a[2usize], &b[2usize]) as i8,
-            u8::ge(&a[3usize], &b[3usize]) as i8,
-            u8::ge(&a[4usize], &b[4usize]) as i8,
-            u8::ge(&a[5usize], &b[5usize]) as i8,
-            u8::ge(&a[6usize], &b[6usize]) as i8,
-            u8::ge(&a[7usize], &b[7usize]) as i8,
-            u8::ge(&a[8usize], &b[8usize]) as i8,
-            u8::ge(&a[9usize], &b[9usize]) as i8,
-            u8::ge(&a[10usize], &b[10usize]) as i8,
-            u8::ge(&a[11usize], &b[11usize]) as i8,
-            u8::ge(&a[12usize], &b[12usize]) as i8,
-            u8::ge(&a[13usize], &b[13usize]) as i8,
-            u8::ge(&a[14usize], &b[14usize]) as i8,
-            u8::ge(&a[15usize], &b[15usize]) as i8,
+            -(u8::ge(&a[0usize], &b[0usize]) as i8),
+            -(u8::ge(&a[1usize], &b[1usize]) as i8),
+            -(u8::ge(&a[2usize], &b[2usize]) as i8),
+            -(u8::ge(&a[3usize], &b[3usize]) as i8),
+            -(u8::ge(&a[4usize], &b[4usize]) as i8),
+            -(u8::ge(&a[5usize], &b[5usize]) as i8),
+            -(u8::ge(&a[6usize], &b[6usize]) as i8),
+            -(u8::ge(&a[7usize], &b[7usize]) as i8),
+            -(u8::ge(&a[8usize], &b[8usize]) as i8),
+            -(u8::ge(&a[9usize], &b[9usize]) as i8),
+            -(u8::ge(&a[10usize], &b[10usize]) as i8),
+            -(u8::ge(&a[11usize], &b[11usize]) as i8),
+            -(u8::ge(&a[12usize], &b[12usize]) as i8),
+            -(u8::ge(&a[13usize], &b[13usize]) as i8),
+            -(u8::ge(&a[14usize], &b[14usize]) as i8),
+            -(u8::ge(&a[15usize], &b[15usize]) as i8),
         ]
             .simd_into(self)
     }
     #[inline(always)]
     fn simd_gt_u8x16(self, a: u8x16<Self>, b: u8x16<Self>) -> mask8x16<Self> {
         [
-            u8::gt(&a[0usize], &b[0usize]) as i8,
-            u8::gt(&a[1usize], &b[1usize]) as i8,
-            u8::gt(&a[2usize], &b[2usize]) as i8,
-            u8::gt(&a[3usize], &b[3usize]) as i8,
-            u8::gt(&a[4usize], &b[4usize]) as i8,
-            u8::gt(&a[5usize], &b[5usize]) as i8,
-            u8::gt(&a[6usize], &b[6usize]) as i8,
-            u8::gt(&a[7usize], &b[7usize]) as i8,
-            u8::gt(&a[8usize], &b[8usize]) as i8,
-            u8::gt(&a[9usize], &b[9usize]) as i8,
-            u8::gt(&a[10usize], &b[10usize]) as i8,
-            u8::gt(&a[11usize], &b[11usize]) as i8,
-            u8::gt(&a[12usize], &b[12usize]) as i8,
-            u8::gt(&a[13usize], &b[13usize]) as i8,
-            u8::gt(&a[14usize], &b[14usize]) as i8,
-            u8::gt(&a[15usize], &b[15usize]) as i8,
+            -(u8::gt(&a[0usize], &b[0usize]) as i8),
+            -(u8::gt(&a[1usize], &b[1usize]) as i8),
+            -(u8::gt(&a[2usize], &b[2usize]) as i8),
+            -(u8::gt(&a[3usize], &b[3usize]) as i8),
+            -(u8::gt(&a[4usize], &b[4usize]) as i8),
+            -(u8::gt(&a[5usize], &b[5usize]) as i8),
+            -(u8::gt(&a[6usize], &b[6usize]) as i8),
+            -(u8::gt(&a[7usize], &b[7usize]) as i8),
+            -(u8::gt(&a[8usize], &b[8usize]) as i8),
+            -(u8::gt(&a[9usize], &b[9usize]) as i8),
+            -(u8::gt(&a[10usize], &b[10usize]) as i8),
+            -(u8::gt(&a[11usize], &b[11usize]) as i8),
+            -(u8::gt(&a[12usize], &b[12usize]) as i8),
+            -(u8::gt(&a[13usize], &b[13usize]) as i8),
+            -(u8::gt(&a[14usize], &b[14usize]) as i8),
+            -(u8::gt(&a[15usize], &b[15usize]) as i8),
         ]
             .simd_into(self)
     }
@@ -1277,22 +1277,22 @@ impl Simd for Fallback {
     #[inline(always)]
     fn simd_eq_mask8x16(self, a: mask8x16<Self>, b: mask8x16<Self>) -> mask8x16<Self> {
         [
-            i8::eq(&a[0usize], &b[0usize]) as i8,
-            i8::eq(&a[1usize], &b[1usize]) as i8,
-            i8::eq(&a[2usize], &b[2usize]) as i8,
-            i8::eq(&a[3usize], &b[3usize]) as i8,
-            i8::eq(&a[4usize], &b[4usize]) as i8,
-            i8::eq(&a[5usize], &b[5usize]) as i8,
-            i8::eq(&a[6usize], &b[6usize]) as i8,
-            i8::eq(&a[7usize], &b[7usize]) as i8,
-            i8::eq(&a[8usize], &b[8usize]) as i8,
-            i8::eq(&a[9usize], &b[9usize]) as i8,
-            i8::eq(&a[10usize], &b[10usize]) as i8,
-            i8::eq(&a[11usize], &b[11usize]) as i8,
-            i8::eq(&a[12usize], &b[12usize]) as i8,
-            i8::eq(&a[13usize], &b[13usize]) as i8,
-            i8::eq(&a[14usize], &b[14usize]) as i8,
-            i8::eq(&a[15usize], &b[15usize]) as i8,
+            -(i8::eq(&a[0usize], &b[0usize]) as i8),
+            -(i8::eq(&a[1usize], &b[1usize]) as i8),
+            -(i8::eq(&a[2usize], &b[2usize]) as i8),
+            -(i8::eq(&a[3usize], &b[3usize]) as i8),
+            -(i8::eq(&a[4usize], &b[4usize]) as i8),
+            -(i8::eq(&a[5usize], &b[5usize]) as i8),
+            -(i8::eq(&a[6usize], &b[6usize]) as i8),
+            -(i8::eq(&a[7usize], &b[7usize]) as i8),
+            -(i8::eq(&a[8usize], &b[8usize]) as i8),
+            -(i8::eq(&a[9usize], &b[9usize]) as i8),
+            -(i8::eq(&a[10usize], &b[10usize]) as i8),
+            -(i8::eq(&a[11usize], &b[11usize]) as i8),
+            -(i8::eq(&a[12usize], &b[12usize]) as i8),
+            -(i8::eq(&a[13usize], &b[13usize]) as i8),
+            -(i8::eq(&a[14usize], &b[14usize]) as i8),
+            -(i8::eq(&a[15usize], &b[15usize]) as i8),
         ]
             .simd_into(self)
     }
@@ -1408,70 +1408,70 @@ impl Simd for Fallback {
     #[inline(always)]
     fn simd_eq_i16x8(self, a: i16x8<Self>, b: i16x8<Self>) -> mask16x8<Self> {
         [
-            i16::eq(&a[0usize], &b[0usize]) as i16,
-            i16::eq(&a[1usize], &b[1usize]) as i16,
-            i16::eq(&a[2usize], &b[2usize]) as i16,
-            i16::eq(&a[3usize], &b[3usize]) as i16,
-            i16::eq(&a[4usize], &b[4usize]) as i16,
-            i16::eq(&a[5usize], &b[5usize]) as i16,
-            i16::eq(&a[6usize], &b[6usize]) as i16,
-            i16::eq(&a[7usize], &b[7usize]) as i16,
+            -(i16::eq(&a[0usize], &b[0usize]) as i16),
+            -(i16::eq(&a[1usize], &b[1usize]) as i16),
+            -(i16::eq(&a[2usize], &b[2usize]) as i16),
+            -(i16::eq(&a[3usize], &b[3usize]) as i16),
+            -(i16::eq(&a[4usize], &b[4usize]) as i16),
+            -(i16::eq(&a[5usize], &b[5usize]) as i16),
+            -(i16::eq(&a[6usize], &b[6usize]) as i16),
+            -(i16::eq(&a[7usize], &b[7usize]) as i16),
         ]
             .simd_into(self)
     }
     #[inline(always)]
     fn simd_lt_i16x8(self, a: i16x8<Self>, b: i16x8<Self>) -> mask16x8<Self> {
         [
-            i16::lt(&a[0usize], &b[0usize]) as i16,
-            i16::lt(&a[1usize], &b[1usize]) as i16,
-            i16::lt(&a[2usize], &b[2usize]) as i16,
-            i16::lt(&a[3usize], &b[3usize]) as i16,
-            i16::lt(&a[4usize], &b[4usize]) as i16,
-            i16::lt(&a[5usize], &b[5usize]) as i16,
-            i16::lt(&a[6usize], &b[6usize]) as i16,
-            i16::lt(&a[7usize], &b[7usize]) as i16,
+            -(i16::lt(&a[0usize], &b[0usize]) as i16),
+            -(i16::lt(&a[1usize], &b[1usize]) as i16),
+            -(i16::lt(&a[2usize], &b[2usize]) as i16),
+            -(i16::lt(&a[3usize], &b[3usize]) as i16),
+            -(i16::lt(&a[4usize], &b[4usize]) as i16),
+            -(i16::lt(&a[5usize], &b[5usize]) as i16),
+            -(i16::lt(&a[6usize], &b[6usize]) as i16),
+            -(i16::lt(&a[7usize], &b[7usize]) as i16),
         ]
             .simd_into(self)
     }
     #[inline(always)]
     fn simd_le_i16x8(self, a: i16x8<Self>, b: i16x8<Self>) -> mask16x8<Self> {
         [
-            i16::le(&a[0usize], &b[0usize]) as i16,
-            i16::le(&a[1usize], &b[1usize]) as i16,
-            i16::le(&a[2usize], &b[2usize]) as i16,
-            i16::le(&a[3usize], &b[3usize]) as i16,
-            i16::le(&a[4usize], &b[4usize]) as i16,
-            i16::le(&a[5usize], &b[5usize]) as i16,
-            i16::le(&a[6usize], &b[6usize]) as i16,
-            i16::le(&a[7usize], &b[7usize]) as i16,
+            -(i16::le(&a[0usize], &b[0usize]) as i16),
+            -(i16::le(&a[1usize], &b[1usize]) as i16),
+            -(i16::le(&a[2usize], &b[2usize]) as i16),
+            -(i16::le(&a[3usize], &b[3usize]) as i16),
+            -(i16::le(&a[4usize], &b[4usize]) as i16),
+            -(i16::le(&a[5usize], &b[5usize]) as i16),
+            -(i16::le(&a[6usize], &b[6usize]) as i16),
+            -(i16::le(&a[7usize], &b[7usize]) as i16),
         ]
             .simd_into(self)
     }
     #[inline(always)]
     fn simd_ge_i16x8(self, a: i16x8<Self>, b: i16x8<Self>) -> mask16x8<Self> {
         [
-            i16::ge(&a[0usize], &b[0usize]) as i16,
-            i16::ge(&a[1usize], &b[1usize]) as i16,
-            i16::ge(&a[2usize], &b[2usize]) as i16,
-            i16::ge(&a[3usize], &b[3usize]) as i16,
-            i16::ge(&a[4usize], &b[4usize]) as i16,
-            i16::ge(&a[5usize], &b[5usize]) as i16,
-            i16::ge(&a[6usize], &b[6usize]) as i16,
-            i16::ge(&a[7usize], &b[7usize]) as i16,
+            -(i16::ge(&a[0usize], &b[0usize]) as i16),
+            -(i16::ge(&a[1usize], &b[1usize]) as i16),
+            -(i16::ge(&a[2usize], &b[2usize]) as i16),
+            -(i16::ge(&a[3usize], &b[3usize]) as i16),
+            -(i16::ge(&a[4usize], &b[4usize]) as i16),
+            -(i16::ge(&a[5usize], &b[5usize]) as i16),
+            -(i16::ge(&a[6usize], &b[6usize]) as i16),
+            -(i16::ge(&a[7usize], &b[7usize]) as i16),
         ]
             .simd_into(self)
     }
     #[inline(always)]
     fn simd_gt_i16x8(self, a: i16x8<Self>, b: i16x8<Self>) -> mask16x8<Self> {
         [
-            i16::gt(&a[0usize], &b[0usize]) as i16,
-            i16::gt(&a[1usize], &b[1usize]) as i16,
-            i16::gt(&a[2usize], &b[2usize]) as i16,
-            i16::gt(&a[3usize], &b[3usize]) as i16,
-            i16::gt(&a[4usize], &b[4usize]) as i16,
-            i16::gt(&a[5usize], &b[5usize]) as i16,
-            i16::gt(&a[6usize], &b[6usize]) as i16,
-            i16::gt(&a[7usize], &b[7usize]) as i16,
+            -(i16::gt(&a[0usize], &b[0usize]) as i16),
+            -(i16::gt(&a[1usize], &b[1usize]) as i16),
+            -(i16::gt(&a[2usize], &b[2usize]) as i16),
+            -(i16::gt(&a[3usize], &b[3usize]) as i16),
+            -(i16::gt(&a[4usize], &b[4usize]) as i16),
+            -(i16::gt(&a[5usize], &b[5usize]) as i16),
+            -(i16::gt(&a[6usize], &b[6usize]) as i16),
+            -(i16::gt(&a[7usize], &b[7usize]) as i16),
         ]
             .simd_into(self)
     }
@@ -1660,70 +1660,70 @@ impl Simd for Fallback {
     #[inline(always)]
     fn simd_eq_u16x8(self, a: u16x8<Self>, b: u16x8<Self>) -> mask16x8<Self> {
         [
-            u16::eq(&a[0usize], &b[0usize]) as i16,
-            u16::eq(&a[1usize], &b[1usize]) as i16,
-            u16::eq(&a[2usize], &b[2usize]) as i16,
-            u16::eq(&a[3usize], &b[3usize]) as i16,
-            u16::eq(&a[4usize], &b[4usize]) as i16,
-            u16::eq(&a[5usize], &b[5usize]) as i16,
-            u16::eq(&a[6usize], &b[6usize]) as i16,
-            u16::eq(&a[7usize], &b[7usize]) as i16,
+            -(u16::eq(&a[0usize], &b[0usize]) as i16),
+            -(u16::eq(&a[1usize], &b[1usize]) as i16),
+            -(u16::eq(&a[2usize], &b[2usize]) as i16),
+            -(u16::eq(&a[3usize], &b[3usize]) as i16),
+            -(u16::eq(&a[4usize], &b[4usize]) as i16),
+            -(u16::eq(&a[5usize], &b[5usize]) as i16),
+            -(u16::eq(&a[6usize], &b[6usize]) as i16),
+            -(u16::eq(&a[7usize], &b[7usize]) as i16),
         ]
             .simd_into(self)
     }
     #[inline(always)]
     fn simd_lt_u16x8(self, a: u16x8<Self>, b: u16x8<Self>) -> mask16x8<Self> {
         [
-            u16::lt(&a[0usize], &b[0usize]) as i16,
-            u16::lt(&a[1usize], &b[1usize]) as i16,
-            u16::lt(&a[2usize], &b[2usize]) as i16,
-            u16::lt(&a[3usize], &b[3usize]) as i16,
-            u16::lt(&a[4usize], &b[4usize]) as i16,
-            u16::lt(&a[5usize], &b[5usize]) as i16,
-            u16::lt(&a[6usize], &b[6usize]) as i16,
-            u16::lt(&a[7usize], &b[7usize]) as i16,
+            -(u16::lt(&a[0usize], &b[0usize]) as i16),
+            -(u16::lt(&a[1usize], &b[1usize]) as i16),
+            -(u16::lt(&a[2usize], &b[2usize]) as i16),
+            -(u16::lt(&a[3usize], &b[3usize]) as i16),
+            -(u16::lt(&a[4usize], &b[4usize]) as i16),
+            -(u16::lt(&a[5usize], &b[5usize]) as i16),
+            -(u16::lt(&a[6usize], &b[6usize]) as i16),
+            -(u16::lt(&a[7usize], &b[7usize]) as i16),
         ]
             .simd_into(self)
     }
     #[inline(always)]
     fn simd_le_u16x8(self, a: u16x8<Self>, b: u16x8<Self>) -> mask16x8<Self> {
         [
-            u16::le(&a[0usize], &b[0usize]) as i16,
-            u16::le(&a[1usize], &b[1usize]) as i16,
-            u16::le(&a[2usize], &b[2usize]) as i16,
-            u16::le(&a[3usize], &b[3usize]) as i16,
-            u16::le(&a[4usize], &b[4usize]) as i16,
-            u16::le(&a[5usize], &b[5usize]) as i16,
-            u16::le(&a[6usize], &b[6usize]) as i16,
-            u16::le(&a[7usize], &b[7usize]) as i16,
+            -(u16::le(&a[0usize], &b[0usize]) as i16),
+            -(u16::le(&a[1usize], &b[1usize]) as i16),
+            -(u16::le(&a[2usize], &b[2usize]) as i16),
+            -(u16::le(&a[3usize], &b[3usize]) as i16),
+            -(u16::le(&a[4usize], &b[4usize]) as i16),
+            -(u16::le(&a[5usize], &b[5usize]) as i16),
+            -(u16::le(&a[6usize], &b[6usize]) as i16),
+            -(u16::le(&a[7usize], &b[7usize]) as i16),
         ]
             .simd_into(self)
     }
     #[inline(always)]
     fn simd_ge_u16x8(self, a: u16x8<Self>, b: u16x8<Self>) -> mask16x8<Self> {
         [
-            u16::ge(&a[0usize], &b[0usize]) as i16,
-            u16::ge(&a[1usize], &b[1usize]) as i16,
-            u16::ge(&a[2usize], &b[2usize]) as i16,
-            u16::ge(&a[3usize], &b[3usize]) as i16,
-            u16::ge(&a[4usize], &b[4usize]) as i16,
-            u16::ge(&a[5usize], &b[5usize]) as i16,
-            u16::ge(&a[6usize], &b[6usize]) as i16,
-            u16::ge(&a[7usize], &b[7usize]) as i16,
+            -(u16::ge(&a[0usize], &b[0usize]) as i16),
+            -(u16::ge(&a[1usize], &b[1usize]) as i16),
+            -(u16::ge(&a[2usize], &b[2usize]) as i16),
+            -(u16::ge(&a[3usize], &b[3usize]) as i16),
+            -(u16::ge(&a[4usize], &b[4usize]) as i16),
+            -(u16::ge(&a[5usize], &b[5usize]) as i16),
+            -(u16::ge(&a[6usize], &b[6usize]) as i16),
+            -(u16::ge(&a[7usize], &b[7usize]) as i16),
         ]
             .simd_into(self)
     }
     #[inline(always)]
     fn simd_gt_u16x8(self, a: u16x8<Self>, b: u16x8<Self>) -> mask16x8<Self> {
         [
-            u16::gt(&a[0usize], &b[0usize]) as i16,
-            u16::gt(&a[1usize], &b[1usize]) as i16,
-            u16::gt(&a[2usize], &b[2usize]) as i16,
-            u16::gt(&a[3usize], &b[3usize]) as i16,
-            u16::gt(&a[4usize], &b[4usize]) as i16,
-            u16::gt(&a[5usize], &b[5usize]) as i16,
-            u16::gt(&a[6usize], &b[6usize]) as i16,
-            u16::gt(&a[7usize], &b[7usize]) as i16,
+            -(u16::gt(&a[0usize], &b[0usize]) as i16),
+            -(u16::gt(&a[1usize], &b[1usize]) as i16),
+            -(u16::gt(&a[2usize], &b[2usize]) as i16),
+            -(u16::gt(&a[3usize], &b[3usize]) as i16),
+            -(u16::gt(&a[4usize], &b[4usize]) as i16),
+            -(u16::gt(&a[5usize], &b[5usize]) as i16),
+            -(u16::gt(&a[6usize], &b[6usize]) as i16),
+            -(u16::gt(&a[7usize], &b[7usize]) as i16),
         ]
             .simd_into(self)
     }
@@ -1951,14 +1951,14 @@ impl Simd for Fallback {
     #[inline(always)]
     fn simd_eq_mask16x8(self, a: mask16x8<Self>, b: mask16x8<Self>) -> mask16x8<Self> {
         [
-            i16::eq(&a[0usize], &b[0usize]) as i16,
-            i16::eq(&a[1usize], &b[1usize]) as i16,
-            i16::eq(&a[2usize], &b[2usize]) as i16,
-            i16::eq(&a[3usize], &b[3usize]) as i16,
-            i16::eq(&a[4usize], &b[4usize]) as i16,
-            i16::eq(&a[5usize], &b[5usize]) as i16,
-            i16::eq(&a[6usize], &b[6usize]) as i16,
-            i16::eq(&a[7usize], &b[7usize]) as i16,
+            -(i16::eq(&a[0usize], &b[0usize]) as i16),
+            -(i16::eq(&a[1usize], &b[1usize]) as i16),
+            -(i16::eq(&a[2usize], &b[2usize]) as i16),
+            -(i16::eq(&a[3usize], &b[3usize]) as i16),
+            -(i16::eq(&a[4usize], &b[4usize]) as i16),
+            -(i16::eq(&a[5usize], &b[5usize]) as i16),
+            -(i16::eq(&a[6usize], &b[6usize]) as i16),
+            -(i16::eq(&a[7usize], &b[7usize]) as i16),
         ]
             .simd_into(self)
     }
@@ -2046,50 +2046,50 @@ impl Simd for Fallback {
     #[inline(always)]
     fn simd_eq_i32x4(self, a: i32x4<Self>, b: i32x4<Self>) -> mask32x4<Self> {
         [
-            i32::eq(&a[0usize], &b[0usize]) as i32,
-            i32::eq(&a[1usize], &b[1usize]) as i32,
-            i32::eq(&a[2usize], &b[2usize]) as i32,
-            i32::eq(&a[3usize], &b[3usize]) as i32,
+            -(i32::eq(&a[0usize], &b[0usize]) as i32),
+            -(i32::eq(&a[1usize], &b[1usize]) as i32),
+            -(i32::eq(&a[2usize], &b[2usize]) as i32),
+            -(i32::eq(&a[3usize], &b[3usize]) as i32),
         ]
             .simd_into(self)
     }
     #[inline(always)]
     fn simd_lt_i32x4(self, a: i32x4<Self>, b: i32x4<Self>) -> mask32x4<Self> {
         [
-            i32::lt(&a[0usize], &b[0usize]) as i32,
-            i32::lt(&a[1usize], &b[1usize]) as i32,
-            i32::lt(&a[2usize], &b[2usize]) as i32,
-            i32::lt(&a[3usize], &b[3usize]) as i32,
+            -(i32::lt(&a[0usize], &b[0usize]) as i32),
+            -(i32::lt(&a[1usize], &b[1usize]) as i32),
+            -(i32::lt(&a[2usize], &b[2usize]) as i32),
+            -(i32::lt(&a[3usize], &b[3usize]) as i32),
         ]
             .simd_into(self)
     }
     #[inline(always)]
     fn simd_le_i32x4(self, a: i32x4<Self>, b: i32x4<Self>) -> mask32x4<Self> {
         [
-            i32::le(&a[0usize], &b[0usize]) as i32,
-            i32::le(&a[1usize], &b[1usize]) as i32,
-            i32::le(&a[2usize], &b[2usize]) as i32,
-            i32::le(&a[3usize], &b[3usize]) as i32,
+            -(i32::le(&a[0usize], &b[0usize]) as i32),
+            -(i32::le(&a[1usize], &b[1usize]) as i32),
+            -(i32::le(&a[2usize], &b[2usize]) as i32),
+            -(i32::le(&a[3usize], &b[3usize]) as i32),
         ]
             .simd_into(self)
     }
     #[inline(always)]
     fn simd_ge_i32x4(self, a: i32x4<Self>, b: i32x4<Self>) -> mask32x4<Self> {
         [
-            i32::ge(&a[0usize], &b[0usize]) as i32,
-            i32::ge(&a[1usize], &b[1usize]) as i32,
-            i32::ge(&a[2usize], &b[2usize]) as i32,
-            i32::ge(&a[3usize], &b[3usize]) as i32,
+            -(i32::ge(&a[0usize], &b[0usize]) as i32),
+            -(i32::ge(&a[1usize], &b[1usize]) as i32),
+            -(i32::ge(&a[2usize], &b[2usize]) as i32),
+            -(i32::ge(&a[3usize], &b[3usize]) as i32),
         ]
             .simd_into(self)
     }
     #[inline(always)]
     fn simd_gt_i32x4(self, a: i32x4<Self>, b: i32x4<Self>) -> mask32x4<Self> {
         [
-            i32::gt(&a[0usize], &b[0usize]) as i32,
-            i32::gt(&a[1usize], &b[1usize]) as i32,
-            i32::gt(&a[2usize], &b[2usize]) as i32,
-            i32::gt(&a[3usize], &b[3usize]) as i32,
+            -(i32::gt(&a[0usize], &b[0usize]) as i32),
+            -(i32::gt(&a[1usize], &b[1usize]) as i32),
+            -(i32::gt(&a[2usize], &b[2usize]) as i32),
+            -(i32::gt(&a[3usize], &b[3usize]) as i32),
         ]
             .simd_into(self)
     }
@@ -2207,50 +2207,50 @@ impl Simd for Fallback {
     #[inline(always)]
     fn simd_eq_u32x4(self, a: u32x4<Self>, b: u32x4<Self>) -> mask32x4<Self> {
         [
-            u32::eq(&a[0usize], &b[0usize]) as i32,
-            u32::eq(&a[1usize], &b[1usize]) as i32,
-            u32::eq(&a[2usize], &b[2usize]) as i32,
-            u32::eq(&a[3usize], &b[3usize]) as i32,
+            -(u32::eq(&a[0usize], &b[0usize]) as i32),
+            -(u32::eq(&a[1usize], &b[1usize]) as i32),
+            -(u32::eq(&a[2usize], &b[2usize]) as i32),
+            -(u32::eq(&a[3usize], &b[3usize]) as i32),
         ]
             .simd_into(self)
     }
     #[inline(always)]
     fn simd_lt_u32x4(self, a: u32x4<Self>, b: u32x4<Self>) -> mask32x4<Self> {
         [
-            u32::lt(&a[0usize], &b[0usize]) as i32,
-            u32::lt(&a[1usize], &b[1usize]) as i32,
-            u32::lt(&a[2usize], &b[2usize]) as i32,
-            u32::lt(&a[3usize], &b[3usize]) as i32,
+            -(u32::lt(&a[0usize], &b[0usize]) as i32),
+            -(u32::lt(&a[1usize], &b[1usize]) as i32),
+            -(u32::lt(&a[2usize], &b[2usize]) as i32),
+            -(u32::lt(&a[3usize], &b[3usize]) as i32),
         ]
             .simd_into(self)
     }
     #[inline(always)]
     fn simd_le_u32x4(self, a: u32x4<Self>, b: u32x4<Self>) -> mask32x4<Self> {
         [
-            u32::le(&a[0usize], &b[0usize]) as i32,
-            u32::le(&a[1usize], &b[1usize]) as i32,
-            u32::le(&a[2usize], &b[2usize]) as i32,
-            u32::le(&a[3usize], &b[3usize]) as i32,
+            -(u32::le(&a[0usize], &b[0usize]) as i32),
+            -(u32::le(&a[1usize], &b[1usize]) as i32),
+            -(u32::le(&a[2usize], &b[2usize]) as i32),
+            -(u32::le(&a[3usize], &b[3usize]) as i32),
         ]
             .simd_into(self)
     }
     #[inline(always)]
     fn simd_ge_u32x4(self, a: u32x4<Self>, b: u32x4<Self>) -> mask32x4<Self> {
         [
-            u32::ge(&a[0usize], &b[0usize]) as i32,
-            u32::ge(&a[1usize], &b[1usize]) as i32,
-            u32::ge(&a[2usize], &b[2usize]) as i32,
-            u32::ge(&a[3usize], &b[3usize]) as i32,
+            -(u32::ge(&a[0usize], &b[0usize]) as i32),
+            -(u32::ge(&a[1usize], &b[1usize]) as i32),
+            -(u32::ge(&a[2usize], &b[2usize]) as i32),
+            -(u32::ge(&a[3usize], &b[3usize]) as i32),
         ]
             .simd_into(self)
     }
     #[inline(always)]
     fn simd_gt_u32x4(self, a: u32x4<Self>, b: u32x4<Self>) -> mask32x4<Self> {
         [
-            u32::gt(&a[0usize], &b[0usize]) as i32,
-            u32::gt(&a[1usize], &b[1usize]) as i32,
-            u32::gt(&a[2usize], &b[2usize]) as i32,
-            u32::gt(&a[3usize], &b[3usize]) as i32,
+            -(u32::gt(&a[0usize], &b[0usize]) as i32),
+            -(u32::gt(&a[1usize], &b[1usize]) as i32),
+            -(u32::gt(&a[2usize], &b[2usize]) as i32),
+            -(u32::gt(&a[3usize], &b[3usize]) as i32),
         ]
             .simd_into(self)
     }
@@ -2376,10 +2376,10 @@ impl Simd for Fallback {
     #[inline(always)]
     fn simd_eq_mask32x4(self, a: mask32x4<Self>, b: mask32x4<Self>) -> mask32x4<Self> {
         [
-            i32::eq(&a[0usize], &b[0usize]) as i32,
-            i32::eq(&a[1usize], &b[1usize]) as i32,
-            i32::eq(&a[2usize], &b[2usize]) as i32,
-            i32::eq(&a[3usize], &b[3usize]) as i32,
+            -(i32::eq(&a[0usize], &b[0usize]) as i32),
+            -(i32::eq(&a[1usize], &b[1usize]) as i32),
+            -(i32::eq(&a[2usize], &b[2usize]) as i32),
+            -(i32::eq(&a[3usize], &b[3usize]) as i32),
         ]
             .simd_into(self)
     }

--- a/fearless_simd/src/generated/wasm.rs
+++ b/fearless_simd/src/generated/wasm.rs
@@ -1,0 +1,2070 @@
+use core::arch::wasm32::*;
+use crate::{seal::Seal, Level, Simd, SimdFrom, SimdInto};
+use crate::{
+    f32x4, i8x16, u8x16, mask8x16, i16x8, u16x8, mask16x8, i32x4, u32x4, mask32x4, f32x8,
+    i8x32, u8x32, mask8x32, i16x16, u16x16, mask16x16, i32x8, u32x8, mask32x8,
+};
+/// The SIMD token for the "wasm128" level.
+#[derive(Clone, Copy, Debug)]
+pub struct WasmSimd128 {
+    _private: (),
+}
+impl WasmSimd128 {
+    #[inline]
+    pub fn new_unchecked() -> Self {
+        Self { _private: () }
+    }
+}
+impl Seal for WasmSimd128 {}
+impl Simd for WasmSimd128 {
+    type f32s = f32x4<Self>;
+    type u8s = u8x16<Self>;
+    type i8s = i8x16<Self>;
+    type u16s = u16x8<Self>;
+    type i16s = i16x8<Self>;
+    type u32s = u32x4<Self>;
+    type i32s = i32x4<Self>;
+    type mask8s = mask8x16<Self>;
+    type mask16s = mask16x8<Self>;
+    type mask32s = mask32x4<Self>;
+    #[inline(always)]
+    fn level(self) -> Level {
+        Level::WasmSimd128(self)
+    }
+    #[inline]
+    fn vectorize<F: FnOnce() -> R, R>(self, f: F) -> R {
+        #[target_feature(enable = "simd128")]
+        #[inline]
+        unsafe fn vectorize_simd128<F: FnOnce() -> R, R>(f: F) -> R {
+            f()
+        }
+        unsafe { vectorize_simd128(f) }
+    }
+    #[inline(always)]
+    fn splat_f32x4(self, val: f32) -> f32x4<Self> {
+        f32x4_splat(val).simd_into(self)
+    }
+    #[inline(always)]
+    fn abs_f32x4(self, a: f32x4<Self>) -> f32x4<Self> {
+        f32x4_abs(a.into()).simd_into(self)
+    }
+    #[inline(always)]
+    fn neg_f32x4(self, a: f32x4<Self>) -> f32x4<Self> {
+        f32x4_neg(a.into()).simd_into(self)
+    }
+    #[inline(always)]
+    fn sqrt_f32x4(self, a: f32x4<Self>) -> f32x4<Self> {
+        f32x4_sqrt(a.into()).simd_into(self)
+    }
+    #[inline(always)]
+    fn add_f32x4(self, a: f32x4<Self>, b: f32x4<Self>) -> f32x4<Self> {
+        f32x4_add(a.into(), b.into()).simd_into(self)
+    }
+    #[inline(always)]
+    fn sub_f32x4(self, a: f32x4<Self>, b: f32x4<Self>) -> f32x4<Self> {
+        f32x4_sub(a.into(), b.into()).simd_into(self)
+    }
+    #[inline(always)]
+    fn mul_f32x4(self, a: f32x4<Self>, b: f32x4<Self>) -> f32x4<Self> {
+        f32x4_mul(a.into(), b.into()).simd_into(self)
+    }
+    #[inline(always)]
+    fn div_f32x4(self, a: f32x4<Self>, b: f32x4<Self>) -> f32x4<Self> {
+        f32x4_div(a.into(), b.into()).simd_into(self)
+    }
+    #[inline(always)]
+    fn copysign_f32x4(self, a: f32x4<Self>, b: f32x4<Self>) -> f32x4<Self> {
+        /// TODO: copysign
+        todo!()
+    }
+    #[inline(always)]
+    fn simd_eq_f32x4(self, a: f32x4<Self>, b: f32x4<Self>) -> mask32x4<Self> {
+        f32x4_eq(a.into(), b.into()).simd_into(self)
+    }
+    #[inline(always)]
+    fn simd_lt_f32x4(self, a: f32x4<Self>, b: f32x4<Self>) -> mask32x4<Self> {
+        f32x4_lt(a.into(), b.into()).simd_into(self)
+    }
+    #[inline(always)]
+    fn simd_le_f32x4(self, a: f32x4<Self>, b: f32x4<Self>) -> mask32x4<Self> {
+        f32x4_le(a.into(), b.into()).simd_into(self)
+    }
+    #[inline(always)]
+    fn simd_ge_f32x4(self, a: f32x4<Self>, b: f32x4<Self>) -> mask32x4<Self> {
+        f32x4_ge(a.into(), b.into()).simd_into(self)
+    }
+    #[inline(always)]
+    fn simd_gt_f32x4(self, a: f32x4<Self>, b: f32x4<Self>) -> mask32x4<Self> {
+        f32x4_gt(a.into(), b.into()).simd_into(self)
+    }
+    #[inline(always)]
+    fn zip_f32x4(self, a: f32x4<Self>, b: f32x4<Self>) -> (f32x4<Self>, f32x4<Self>) {
+        todo!()
+    }
+    #[inline(always)]
+    fn unzip_f32x4(self, a: f32x4<Self>, b: f32x4<Self>) -> (f32x4<Self>, f32x4<Self>) {
+        todo!()
+    }
+    #[inline(always)]
+    fn max_f32x4(self, a: f32x4<Self>, b: f32x4<Self>) -> f32x4<Self> {
+        f32x4_max(a.into(), b.into()).simd_into(self)
+    }
+    #[inline(always)]
+    fn max_precise_f32x4(self, a: f32x4<Self>, b: f32x4<Self>) -> f32x4<Self> {
+        f32x4_max(a.into(), b.into()).simd_into(self)
+    }
+    #[inline(always)]
+    fn min_f32x4(self, a: f32x4<Self>, b: f32x4<Self>) -> f32x4<Self> {
+        f32x4_min(a.into(), b.into()).simd_into(self)
+    }
+    #[inline(always)]
+    fn min_precise_f32x4(self, a: f32x4<Self>, b: f32x4<Self>) -> f32x4<Self> {
+        f32x4_min(a.into(), b.into()).simd_into(self)
+    }
+    #[inline(always)]
+    fn madd_f32x4(self, a: f32x4<Self>, b: f32x4<Self>, c: f32x4<Self>) -> f32x4<Self> {
+        self.add_f32x4(a, self.mul_f32x4(b, c))
+    }
+    #[inline(always)]
+    fn floor_f32x4(self, a: f32x4<Self>) -> f32x4<Self> {
+        f32x4_floor(a.into()).simd_into(self)
+    }
+    #[inline(always)]
+    fn select_f32x4(
+        self,
+        a: mask32x4<Self>,
+        b: f32x4<Self>,
+        c: f32x4<Self>,
+    ) -> f32x4<Self> {
+        todo!()
+    }
+    #[inline(always)]
+    fn combine_f32x4(self, a: f32x4<Self>, b: f32x4<Self>) -> f32x8<Self> {
+        let mut result = [0.0; 8usize];
+        result[0..4usize].copy_from_slice(&a.val);
+        result[4usize..8usize].copy_from_slice(&b.val);
+        result.simd_into(self)
+    }
+    #[inline(always)]
+    fn cvt_u32_f32x4(self, a: f32x4<Self>) -> u32x4<Self> {
+        todo!()
+    }
+    #[inline(always)]
+    fn splat_i8x16(self, val: i8) -> i8x16<Self> {
+        i8x16_splat(val).simd_into(self)
+    }
+    #[inline(always)]
+    fn not_i8x16(self, a: i8x16<Self>) -> i8x16<Self> {
+        /// TODO: If v128 is used, we need to reinterpret it.
+        todo!()
+    }
+    #[inline(always)]
+    fn add_i8x16(self, a: i8x16<Self>, b: i8x16<Self>) -> i8x16<Self> {
+        i8x16_add(a.into(), b.into()).simd_into(self)
+    }
+    #[inline(always)]
+    fn sub_i8x16(self, a: i8x16<Self>, b: i8x16<Self>) -> i8x16<Self> {
+        i8x16_sub(a.into(), b.into()).simd_into(self)
+    }
+    #[inline(always)]
+    fn mul_i8x16(self, a: i8x16<Self>, b: i8x16<Self>) -> i8x16<Self> {
+        todo!()
+    }
+    #[inline(always)]
+    fn and_i8x16(self, a: i8x16<Self>, b: i8x16<Self>) -> i8x16<Self> {
+        /// TODO: If v128 is used we need to reinterpret it accurately...
+        todo!()
+    }
+    #[inline(always)]
+    fn or_i8x16(self, a: i8x16<Self>, b: i8x16<Self>) -> i8x16<Self> {
+        /// TODO: If v128 is used we need to reinterpret it accurately...
+        todo!()
+    }
+    #[inline(always)]
+    fn xor_i8x16(self, a: i8x16<Self>, b: i8x16<Self>) -> i8x16<Self> {
+        /// TODO: If v128 is used we need to reinterpret it accurately...
+        todo!()
+    }
+    #[inline(always)]
+    fn simd_eq_i8x16(self, a: i8x16<Self>, b: i8x16<Self>) -> mask8x16<Self> {
+        i8x16_eq(a.into(), b.into()).simd_into(self)
+    }
+    #[inline(always)]
+    fn simd_lt_i8x16(self, a: i8x16<Self>, b: i8x16<Self>) -> mask8x16<Self> {
+        i8x16_lt(a.into(), b.into()).simd_into(self)
+    }
+    #[inline(always)]
+    fn simd_le_i8x16(self, a: i8x16<Self>, b: i8x16<Self>) -> mask8x16<Self> {
+        i8x16_le(a.into(), b.into()).simd_into(self)
+    }
+    #[inline(always)]
+    fn simd_ge_i8x16(self, a: i8x16<Self>, b: i8x16<Self>) -> mask8x16<Self> {
+        i8x16_ge(a.into(), b.into()).simd_into(self)
+    }
+    #[inline(always)]
+    fn simd_gt_i8x16(self, a: i8x16<Self>, b: i8x16<Self>) -> mask8x16<Self> {
+        i8x16_gt(a.into(), b.into()).simd_into(self)
+    }
+    #[inline(always)]
+    fn zip_i8x16(self, a: i8x16<Self>, b: i8x16<Self>) -> (i8x16<Self>, i8x16<Self>) {
+        todo!()
+    }
+    #[inline(always)]
+    fn unzip_i8x16(self, a: i8x16<Self>, b: i8x16<Self>) -> (i8x16<Self>, i8x16<Self>) {
+        todo!()
+    }
+    #[inline(always)]
+    fn select_i8x16(
+        self,
+        a: mask8x16<Self>,
+        b: i8x16<Self>,
+        c: i8x16<Self>,
+    ) -> i8x16<Self> {
+        todo!()
+    }
+    #[inline(always)]
+    fn combine_i8x16(self, a: i8x16<Self>, b: i8x16<Self>) -> i8x32<Self> {
+        let mut result = [0; 32usize];
+        result[0..16usize].copy_from_slice(&a.val);
+        result[16usize..32usize].copy_from_slice(&b.val);
+        result.simd_into(self)
+    }
+    #[inline(always)]
+    fn splat_u8x16(self, val: u8) -> u8x16<Self> {
+        u8x16_splat(val).simd_into(self)
+    }
+    #[inline(always)]
+    fn not_u8x16(self, a: u8x16<Self>) -> u8x16<Self> {
+        /// TODO: If v128 is used, we need to reinterpret it.
+        todo!()
+    }
+    #[inline(always)]
+    fn add_u8x16(self, a: u8x16<Self>, b: u8x16<Self>) -> u8x16<Self> {
+        u8x16_add(a.into(), b.into()).simd_into(self)
+    }
+    #[inline(always)]
+    fn sub_u8x16(self, a: u8x16<Self>, b: u8x16<Self>) -> u8x16<Self> {
+        u8x16_sub(a.into(), b.into()).simd_into(self)
+    }
+    #[inline(always)]
+    fn mul_u8x16(self, a: u8x16<Self>, b: u8x16<Self>) -> u8x16<Self> {
+        todo!()
+    }
+    #[inline(always)]
+    fn and_u8x16(self, a: u8x16<Self>, b: u8x16<Self>) -> u8x16<Self> {
+        /// TODO: If v128 is used we need to reinterpret it accurately...
+        todo!()
+    }
+    #[inline(always)]
+    fn or_u8x16(self, a: u8x16<Self>, b: u8x16<Self>) -> u8x16<Self> {
+        /// TODO: If v128 is used we need to reinterpret it accurately...
+        todo!()
+    }
+    #[inline(always)]
+    fn xor_u8x16(self, a: u8x16<Self>, b: u8x16<Self>) -> u8x16<Self> {
+        /// TODO: If v128 is used we need to reinterpret it accurately...
+        todo!()
+    }
+    #[inline(always)]
+    fn simd_eq_u8x16(self, a: u8x16<Self>, b: u8x16<Self>) -> mask8x16<Self> {
+        u8x16_eq(a.into(), b.into()).simd_into(self)
+    }
+    #[inline(always)]
+    fn simd_lt_u8x16(self, a: u8x16<Self>, b: u8x16<Self>) -> mask8x16<Self> {
+        u8x16_lt(a.into(), b.into()).simd_into(self)
+    }
+    #[inline(always)]
+    fn simd_le_u8x16(self, a: u8x16<Self>, b: u8x16<Self>) -> mask8x16<Self> {
+        u8x16_le(a.into(), b.into()).simd_into(self)
+    }
+    #[inline(always)]
+    fn simd_ge_u8x16(self, a: u8x16<Self>, b: u8x16<Self>) -> mask8x16<Self> {
+        u8x16_ge(a.into(), b.into()).simd_into(self)
+    }
+    #[inline(always)]
+    fn simd_gt_u8x16(self, a: u8x16<Self>, b: u8x16<Self>) -> mask8x16<Self> {
+        u8x16_gt(a.into(), b.into()).simd_into(self)
+    }
+    #[inline(always)]
+    fn zip_u8x16(self, a: u8x16<Self>, b: u8x16<Self>) -> (u8x16<Self>, u8x16<Self>) {
+        todo!()
+    }
+    #[inline(always)]
+    fn unzip_u8x16(self, a: u8x16<Self>, b: u8x16<Self>) -> (u8x16<Self>, u8x16<Self>) {
+        todo!()
+    }
+    #[inline(always)]
+    fn select_u8x16(
+        self,
+        a: mask8x16<Self>,
+        b: u8x16<Self>,
+        c: u8x16<Self>,
+    ) -> u8x16<Self> {
+        todo!()
+    }
+    #[inline(always)]
+    fn combine_u8x16(self, a: u8x16<Self>, b: u8x16<Self>) -> u8x32<Self> {
+        let mut result = [0; 32usize];
+        result[0..16usize].copy_from_slice(&a.val);
+        result[16usize..32usize].copy_from_slice(&b.val);
+        result.simd_into(self)
+    }
+    #[inline(always)]
+    fn splat_mask8x16(self, val: i8) -> mask8x16<Self> {
+        i8x16_splat(val).simd_into(self)
+    }
+    #[inline(always)]
+    fn not_mask8x16(self, a: mask8x16<Self>) -> mask8x16<Self> {
+        /// TODO: If v128 is used, we need to reinterpret it.
+        todo!()
+    }
+    #[inline(always)]
+    fn and_mask8x16(self, a: mask8x16<Self>, b: mask8x16<Self>) -> mask8x16<Self> {
+        /// TODO: If v128 is used we need to reinterpret it accurately...
+        todo!()
+    }
+    #[inline(always)]
+    fn or_mask8x16(self, a: mask8x16<Self>, b: mask8x16<Self>) -> mask8x16<Self> {
+        /// TODO: If v128 is used we need to reinterpret it accurately...
+        todo!()
+    }
+    #[inline(always)]
+    fn xor_mask8x16(self, a: mask8x16<Self>, b: mask8x16<Self>) -> mask8x16<Self> {
+        /// TODO: If v128 is used we need to reinterpret it accurately...
+        todo!()
+    }
+    #[inline(always)]
+    fn select_mask8x16(
+        self,
+        a: mask8x16<Self>,
+        b: mask8x16<Self>,
+        c: mask8x16<Self>,
+    ) -> mask8x16<Self> {
+        todo!()
+    }
+    #[inline(always)]
+    fn zip_mask8x16(
+        self,
+        a: mask8x16<Self>,
+        b: mask8x16<Self>,
+    ) -> (mask8x16<Self>, mask8x16<Self>) {
+        todo!()
+    }
+    #[inline(always)]
+    fn unzip_mask8x16(
+        self,
+        a: mask8x16<Self>,
+        b: mask8x16<Self>,
+    ) -> (mask8x16<Self>, mask8x16<Self>) {
+        todo!()
+    }
+    #[inline(always)]
+    fn simd_eq_mask8x16(self, a: mask8x16<Self>, b: mask8x16<Self>) -> mask8x16<Self> {
+        i8x16_eq(a.into(), b.into()).simd_into(self)
+    }
+    #[inline(always)]
+    fn combine_mask8x16(self, a: mask8x16<Self>, b: mask8x16<Self>) -> mask8x32<Self> {
+        let mut result = [0; 32usize];
+        result[0..16usize].copy_from_slice(&a.val);
+        result[16usize..32usize].copy_from_slice(&b.val);
+        result.simd_into(self)
+    }
+    #[inline(always)]
+    fn splat_i16x8(self, val: i16) -> i16x8<Self> {
+        i16x8_splat(val).simd_into(self)
+    }
+    #[inline(always)]
+    fn not_i16x8(self, a: i16x8<Self>) -> i16x8<Self> {
+        /// TODO: If v128 is used, we need to reinterpret it.
+        todo!()
+    }
+    #[inline(always)]
+    fn add_i16x8(self, a: i16x8<Self>, b: i16x8<Self>) -> i16x8<Self> {
+        i16x8_add(a.into(), b.into()).simd_into(self)
+    }
+    #[inline(always)]
+    fn sub_i16x8(self, a: i16x8<Self>, b: i16x8<Self>) -> i16x8<Self> {
+        i16x8_sub(a.into(), b.into()).simd_into(self)
+    }
+    #[inline(always)]
+    fn mul_i16x8(self, a: i16x8<Self>, b: i16x8<Self>) -> i16x8<Self> {
+        i16x8_mul(a.into(), b.into()).simd_into(self)
+    }
+    #[inline(always)]
+    fn and_i16x8(self, a: i16x8<Self>, b: i16x8<Self>) -> i16x8<Self> {
+        /// TODO: If v128 is used we need to reinterpret it accurately...
+        todo!()
+    }
+    #[inline(always)]
+    fn or_i16x8(self, a: i16x8<Self>, b: i16x8<Self>) -> i16x8<Self> {
+        /// TODO: If v128 is used we need to reinterpret it accurately...
+        todo!()
+    }
+    #[inline(always)]
+    fn xor_i16x8(self, a: i16x8<Self>, b: i16x8<Self>) -> i16x8<Self> {
+        /// TODO: If v128 is used we need to reinterpret it accurately...
+        todo!()
+    }
+    #[inline(always)]
+    fn simd_eq_i16x8(self, a: i16x8<Self>, b: i16x8<Self>) -> mask16x8<Self> {
+        i16x8_eq(a.into(), b.into()).simd_into(self)
+    }
+    #[inline(always)]
+    fn simd_lt_i16x8(self, a: i16x8<Self>, b: i16x8<Self>) -> mask16x8<Self> {
+        i16x8_lt(a.into(), b.into()).simd_into(self)
+    }
+    #[inline(always)]
+    fn simd_le_i16x8(self, a: i16x8<Self>, b: i16x8<Self>) -> mask16x8<Self> {
+        i16x8_le(a.into(), b.into()).simd_into(self)
+    }
+    #[inline(always)]
+    fn simd_ge_i16x8(self, a: i16x8<Self>, b: i16x8<Self>) -> mask16x8<Self> {
+        i16x8_ge(a.into(), b.into()).simd_into(self)
+    }
+    #[inline(always)]
+    fn simd_gt_i16x8(self, a: i16x8<Self>, b: i16x8<Self>) -> mask16x8<Self> {
+        i16x8_gt(a.into(), b.into()).simd_into(self)
+    }
+    #[inline(always)]
+    fn zip_i16x8(self, a: i16x8<Self>, b: i16x8<Self>) -> (i16x8<Self>, i16x8<Self>) {
+        todo!()
+    }
+    #[inline(always)]
+    fn unzip_i16x8(self, a: i16x8<Self>, b: i16x8<Self>) -> (i16x8<Self>, i16x8<Self>) {
+        todo!()
+    }
+    #[inline(always)]
+    fn select_i16x8(
+        self,
+        a: mask16x8<Self>,
+        b: i16x8<Self>,
+        c: i16x8<Self>,
+    ) -> i16x8<Self> {
+        todo!()
+    }
+    #[inline(always)]
+    fn combine_i16x8(self, a: i16x8<Self>, b: i16x8<Self>) -> i16x16<Self> {
+        let mut result = [0; 16usize];
+        result[0..8usize].copy_from_slice(&a.val);
+        result[8usize..16usize].copy_from_slice(&b.val);
+        result.simd_into(self)
+    }
+    #[inline(always)]
+    fn splat_u16x8(self, val: u16) -> u16x8<Self> {
+        u16x8_splat(val).simd_into(self)
+    }
+    #[inline(always)]
+    fn not_u16x8(self, a: u16x8<Self>) -> u16x8<Self> {
+        /// TODO: If v128 is used, we need to reinterpret it.
+        todo!()
+    }
+    #[inline(always)]
+    fn add_u16x8(self, a: u16x8<Self>, b: u16x8<Self>) -> u16x8<Self> {
+        u16x8_add(a.into(), b.into()).simd_into(self)
+    }
+    #[inline(always)]
+    fn sub_u16x8(self, a: u16x8<Self>, b: u16x8<Self>) -> u16x8<Self> {
+        u16x8_sub(a.into(), b.into()).simd_into(self)
+    }
+    #[inline(always)]
+    fn mul_u16x8(self, a: u16x8<Self>, b: u16x8<Self>) -> u16x8<Self> {
+        u16x8_mul(a.into(), b.into()).simd_into(self)
+    }
+    #[inline(always)]
+    fn and_u16x8(self, a: u16x8<Self>, b: u16x8<Self>) -> u16x8<Self> {
+        /// TODO: If v128 is used we need to reinterpret it accurately...
+        todo!()
+    }
+    #[inline(always)]
+    fn or_u16x8(self, a: u16x8<Self>, b: u16x8<Self>) -> u16x8<Self> {
+        /// TODO: If v128 is used we need to reinterpret it accurately...
+        todo!()
+    }
+    #[inline(always)]
+    fn xor_u16x8(self, a: u16x8<Self>, b: u16x8<Self>) -> u16x8<Self> {
+        /// TODO: If v128 is used we need to reinterpret it accurately...
+        todo!()
+    }
+    #[inline(always)]
+    fn simd_eq_u16x8(self, a: u16x8<Self>, b: u16x8<Self>) -> mask16x8<Self> {
+        u16x8_eq(a.into(), b.into()).simd_into(self)
+    }
+    #[inline(always)]
+    fn simd_lt_u16x8(self, a: u16x8<Self>, b: u16x8<Self>) -> mask16x8<Self> {
+        u16x8_lt(a.into(), b.into()).simd_into(self)
+    }
+    #[inline(always)]
+    fn simd_le_u16x8(self, a: u16x8<Self>, b: u16x8<Self>) -> mask16x8<Self> {
+        u16x8_le(a.into(), b.into()).simd_into(self)
+    }
+    #[inline(always)]
+    fn simd_ge_u16x8(self, a: u16x8<Self>, b: u16x8<Self>) -> mask16x8<Self> {
+        u16x8_ge(a.into(), b.into()).simd_into(self)
+    }
+    #[inline(always)]
+    fn simd_gt_u16x8(self, a: u16x8<Self>, b: u16x8<Self>) -> mask16x8<Self> {
+        u16x8_gt(a.into(), b.into()).simd_into(self)
+    }
+    #[inline(always)]
+    fn zip_u16x8(self, a: u16x8<Self>, b: u16x8<Self>) -> (u16x8<Self>, u16x8<Self>) {
+        todo!()
+    }
+    #[inline(always)]
+    fn unzip_u16x8(self, a: u16x8<Self>, b: u16x8<Self>) -> (u16x8<Self>, u16x8<Self>) {
+        todo!()
+    }
+    #[inline(always)]
+    fn select_u16x8(
+        self,
+        a: mask16x8<Self>,
+        b: u16x8<Self>,
+        c: u16x8<Self>,
+    ) -> u16x8<Self> {
+        todo!()
+    }
+    #[inline(always)]
+    fn combine_u16x8(self, a: u16x8<Self>, b: u16x8<Self>) -> u16x16<Self> {
+        let mut result = [0; 16usize];
+        result[0..8usize].copy_from_slice(&a.val);
+        result[8usize..16usize].copy_from_slice(&b.val);
+        result.simd_into(self)
+    }
+    #[inline(always)]
+    fn splat_mask16x8(self, val: i16) -> mask16x8<Self> {
+        i16x8_splat(val).simd_into(self)
+    }
+    #[inline(always)]
+    fn not_mask16x8(self, a: mask16x8<Self>) -> mask16x8<Self> {
+        /// TODO: If v128 is used, we need to reinterpret it.
+        todo!()
+    }
+    #[inline(always)]
+    fn and_mask16x8(self, a: mask16x8<Self>, b: mask16x8<Self>) -> mask16x8<Self> {
+        /// TODO: If v128 is used we need to reinterpret it accurately...
+        todo!()
+    }
+    #[inline(always)]
+    fn or_mask16x8(self, a: mask16x8<Self>, b: mask16x8<Self>) -> mask16x8<Self> {
+        /// TODO: If v128 is used we need to reinterpret it accurately...
+        todo!()
+    }
+    #[inline(always)]
+    fn xor_mask16x8(self, a: mask16x8<Self>, b: mask16x8<Self>) -> mask16x8<Self> {
+        /// TODO: If v128 is used we need to reinterpret it accurately...
+        todo!()
+    }
+    #[inline(always)]
+    fn select_mask16x8(
+        self,
+        a: mask16x8<Self>,
+        b: mask16x8<Self>,
+        c: mask16x8<Self>,
+    ) -> mask16x8<Self> {
+        todo!()
+    }
+    #[inline(always)]
+    fn zip_mask16x8(
+        self,
+        a: mask16x8<Self>,
+        b: mask16x8<Self>,
+    ) -> (mask16x8<Self>, mask16x8<Self>) {
+        todo!()
+    }
+    #[inline(always)]
+    fn unzip_mask16x8(
+        self,
+        a: mask16x8<Self>,
+        b: mask16x8<Self>,
+    ) -> (mask16x8<Self>, mask16x8<Self>) {
+        todo!()
+    }
+    #[inline(always)]
+    fn simd_eq_mask16x8(self, a: mask16x8<Self>, b: mask16x8<Self>) -> mask16x8<Self> {
+        i16x8_eq(a.into(), b.into()).simd_into(self)
+    }
+    #[inline(always)]
+    fn combine_mask16x8(self, a: mask16x8<Self>, b: mask16x8<Self>) -> mask16x16<Self> {
+        let mut result = [0; 16usize];
+        result[0..8usize].copy_from_slice(&a.val);
+        result[8usize..16usize].copy_from_slice(&b.val);
+        result.simd_into(self)
+    }
+    #[inline(always)]
+    fn splat_i32x4(self, val: i32) -> i32x4<Self> {
+        i32x4_splat(val).simd_into(self)
+    }
+    #[inline(always)]
+    fn not_i32x4(self, a: i32x4<Self>) -> i32x4<Self> {
+        /// TODO: If v128 is used, we need to reinterpret it.
+        todo!()
+    }
+    #[inline(always)]
+    fn add_i32x4(self, a: i32x4<Self>, b: i32x4<Self>) -> i32x4<Self> {
+        i32x4_add(a.into(), b.into()).simd_into(self)
+    }
+    #[inline(always)]
+    fn sub_i32x4(self, a: i32x4<Self>, b: i32x4<Self>) -> i32x4<Self> {
+        i32x4_sub(a.into(), b.into()).simd_into(self)
+    }
+    #[inline(always)]
+    fn mul_i32x4(self, a: i32x4<Self>, b: i32x4<Self>) -> i32x4<Self> {
+        i32x4_mul(a.into(), b.into()).simd_into(self)
+    }
+    #[inline(always)]
+    fn and_i32x4(self, a: i32x4<Self>, b: i32x4<Self>) -> i32x4<Self> {
+        /// TODO: If v128 is used we need to reinterpret it accurately...
+        todo!()
+    }
+    #[inline(always)]
+    fn or_i32x4(self, a: i32x4<Self>, b: i32x4<Self>) -> i32x4<Self> {
+        /// TODO: If v128 is used we need to reinterpret it accurately...
+        todo!()
+    }
+    #[inline(always)]
+    fn xor_i32x4(self, a: i32x4<Self>, b: i32x4<Self>) -> i32x4<Self> {
+        /// TODO: If v128 is used we need to reinterpret it accurately...
+        todo!()
+    }
+    #[inline(always)]
+    fn simd_eq_i32x4(self, a: i32x4<Self>, b: i32x4<Self>) -> mask32x4<Self> {
+        i32x4_eq(a.into(), b.into()).simd_into(self)
+    }
+    #[inline(always)]
+    fn simd_lt_i32x4(self, a: i32x4<Self>, b: i32x4<Self>) -> mask32x4<Self> {
+        i32x4_lt(a.into(), b.into()).simd_into(self)
+    }
+    #[inline(always)]
+    fn simd_le_i32x4(self, a: i32x4<Self>, b: i32x4<Self>) -> mask32x4<Self> {
+        i32x4_le(a.into(), b.into()).simd_into(self)
+    }
+    #[inline(always)]
+    fn simd_ge_i32x4(self, a: i32x4<Self>, b: i32x4<Self>) -> mask32x4<Self> {
+        i32x4_ge(a.into(), b.into()).simd_into(self)
+    }
+    #[inline(always)]
+    fn simd_gt_i32x4(self, a: i32x4<Self>, b: i32x4<Self>) -> mask32x4<Self> {
+        i32x4_gt(a.into(), b.into()).simd_into(self)
+    }
+    #[inline(always)]
+    fn zip_i32x4(self, a: i32x4<Self>, b: i32x4<Self>) -> (i32x4<Self>, i32x4<Self>) {
+        todo!()
+    }
+    #[inline(always)]
+    fn unzip_i32x4(self, a: i32x4<Self>, b: i32x4<Self>) -> (i32x4<Self>, i32x4<Self>) {
+        todo!()
+    }
+    #[inline(always)]
+    fn select_i32x4(
+        self,
+        a: mask32x4<Self>,
+        b: i32x4<Self>,
+        c: i32x4<Self>,
+    ) -> i32x4<Self> {
+        todo!()
+    }
+    #[inline(always)]
+    fn combine_i32x4(self, a: i32x4<Self>, b: i32x4<Self>) -> i32x8<Self> {
+        let mut result = [0; 8usize];
+        result[0..4usize].copy_from_slice(&a.val);
+        result[4usize..8usize].copy_from_slice(&b.val);
+        result.simd_into(self)
+    }
+    #[inline(always)]
+    fn splat_u32x4(self, val: u32) -> u32x4<Self> {
+        u32x4_splat(val).simd_into(self)
+    }
+    #[inline(always)]
+    fn not_u32x4(self, a: u32x4<Self>) -> u32x4<Self> {
+        /// TODO: If v128 is used, we need to reinterpret it.
+        todo!()
+    }
+    #[inline(always)]
+    fn add_u32x4(self, a: u32x4<Self>, b: u32x4<Self>) -> u32x4<Self> {
+        u32x4_add(a.into(), b.into()).simd_into(self)
+    }
+    #[inline(always)]
+    fn sub_u32x4(self, a: u32x4<Self>, b: u32x4<Self>) -> u32x4<Self> {
+        u32x4_sub(a.into(), b.into()).simd_into(self)
+    }
+    #[inline(always)]
+    fn mul_u32x4(self, a: u32x4<Self>, b: u32x4<Self>) -> u32x4<Self> {
+        u32x4_mul(a.into(), b.into()).simd_into(self)
+    }
+    #[inline(always)]
+    fn and_u32x4(self, a: u32x4<Self>, b: u32x4<Self>) -> u32x4<Self> {
+        /// TODO: If v128 is used we need to reinterpret it accurately...
+        todo!()
+    }
+    #[inline(always)]
+    fn or_u32x4(self, a: u32x4<Self>, b: u32x4<Self>) -> u32x4<Self> {
+        /// TODO: If v128 is used we need to reinterpret it accurately...
+        todo!()
+    }
+    #[inline(always)]
+    fn xor_u32x4(self, a: u32x4<Self>, b: u32x4<Self>) -> u32x4<Self> {
+        /// TODO: If v128 is used we need to reinterpret it accurately...
+        todo!()
+    }
+    #[inline(always)]
+    fn simd_eq_u32x4(self, a: u32x4<Self>, b: u32x4<Self>) -> mask32x4<Self> {
+        u32x4_eq(a.into(), b.into()).simd_into(self)
+    }
+    #[inline(always)]
+    fn simd_lt_u32x4(self, a: u32x4<Self>, b: u32x4<Self>) -> mask32x4<Self> {
+        u32x4_lt(a.into(), b.into()).simd_into(self)
+    }
+    #[inline(always)]
+    fn simd_le_u32x4(self, a: u32x4<Self>, b: u32x4<Self>) -> mask32x4<Self> {
+        u32x4_le(a.into(), b.into()).simd_into(self)
+    }
+    #[inline(always)]
+    fn simd_ge_u32x4(self, a: u32x4<Self>, b: u32x4<Self>) -> mask32x4<Self> {
+        u32x4_ge(a.into(), b.into()).simd_into(self)
+    }
+    #[inline(always)]
+    fn simd_gt_u32x4(self, a: u32x4<Self>, b: u32x4<Self>) -> mask32x4<Self> {
+        u32x4_gt(a.into(), b.into()).simd_into(self)
+    }
+    #[inline(always)]
+    fn zip_u32x4(self, a: u32x4<Self>, b: u32x4<Self>) -> (u32x4<Self>, u32x4<Self>) {
+        todo!()
+    }
+    #[inline(always)]
+    fn unzip_u32x4(self, a: u32x4<Self>, b: u32x4<Self>) -> (u32x4<Self>, u32x4<Self>) {
+        todo!()
+    }
+    #[inline(always)]
+    fn select_u32x4(
+        self,
+        a: mask32x4<Self>,
+        b: u32x4<Self>,
+        c: u32x4<Self>,
+    ) -> u32x4<Self> {
+        todo!()
+    }
+    #[inline(always)]
+    fn combine_u32x4(self, a: u32x4<Self>, b: u32x4<Self>) -> u32x8<Self> {
+        let mut result = [0; 8usize];
+        result[0..4usize].copy_from_slice(&a.val);
+        result[4usize..8usize].copy_from_slice(&b.val);
+        result.simd_into(self)
+    }
+    #[inline(always)]
+    fn splat_mask32x4(self, val: i32) -> mask32x4<Self> {
+        i32x4_splat(val).simd_into(self)
+    }
+    #[inline(always)]
+    fn not_mask32x4(self, a: mask32x4<Self>) -> mask32x4<Self> {
+        /// TODO: If v128 is used, we need to reinterpret it.
+        todo!()
+    }
+    #[inline(always)]
+    fn and_mask32x4(self, a: mask32x4<Self>, b: mask32x4<Self>) -> mask32x4<Self> {
+        /// TODO: If v128 is used we need to reinterpret it accurately...
+        todo!()
+    }
+    #[inline(always)]
+    fn or_mask32x4(self, a: mask32x4<Self>, b: mask32x4<Self>) -> mask32x4<Self> {
+        /// TODO: If v128 is used we need to reinterpret it accurately...
+        todo!()
+    }
+    #[inline(always)]
+    fn xor_mask32x4(self, a: mask32x4<Self>, b: mask32x4<Self>) -> mask32x4<Self> {
+        /// TODO: If v128 is used we need to reinterpret it accurately...
+        todo!()
+    }
+    #[inline(always)]
+    fn select_mask32x4(
+        self,
+        a: mask32x4<Self>,
+        b: mask32x4<Self>,
+        c: mask32x4<Self>,
+    ) -> mask32x4<Self> {
+        todo!()
+    }
+    #[inline(always)]
+    fn zip_mask32x4(
+        self,
+        a: mask32x4<Self>,
+        b: mask32x4<Self>,
+    ) -> (mask32x4<Self>, mask32x4<Self>) {
+        todo!()
+    }
+    #[inline(always)]
+    fn unzip_mask32x4(
+        self,
+        a: mask32x4<Self>,
+        b: mask32x4<Self>,
+    ) -> (mask32x4<Self>, mask32x4<Self>) {
+        todo!()
+    }
+    #[inline(always)]
+    fn simd_eq_mask32x4(self, a: mask32x4<Self>, b: mask32x4<Self>) -> mask32x4<Self> {
+        i32x4_eq(a.into(), b.into()).simd_into(self)
+    }
+    #[inline(always)]
+    fn combine_mask32x4(self, a: mask32x4<Self>, b: mask32x4<Self>) -> mask32x8<Self> {
+        let mut result = [0; 8usize];
+        result[0..4usize].copy_from_slice(&a.val);
+        result[4usize..8usize].copy_from_slice(&b.val);
+        result.simd_into(self)
+    }
+    #[inline(always)]
+    fn splat_f32x8(self, a: f32) -> f32x8<Self> {
+        let half = self.splat_f32x4(a);
+        self.combine_f32x4(half, half)
+    }
+    #[inline(always)]
+    fn abs_f32x8(self, a: f32x8<Self>) -> f32x8<Self> {
+        let (a0, a1) = self.split_f32x8(a);
+        self.combine_f32x4(self.abs_f32x4(a0), self.abs_f32x4(a1))
+    }
+    #[inline(always)]
+    fn neg_f32x8(self, a: f32x8<Self>) -> f32x8<Self> {
+        let (a0, a1) = self.split_f32x8(a);
+        self.combine_f32x4(self.neg_f32x4(a0), self.neg_f32x4(a1))
+    }
+    #[inline(always)]
+    fn sqrt_f32x8(self, a: f32x8<Self>) -> f32x8<Self> {
+        let (a0, a1) = self.split_f32x8(a);
+        self.combine_f32x4(self.sqrt_f32x4(a0), self.sqrt_f32x4(a1))
+    }
+    #[inline(always)]
+    fn add_f32x8(self, a: f32x8<Self>, b: f32x8<Self>) -> f32x8<Self> {
+        let (a0, a1) = self.split_f32x8(a);
+        let (b0, b1) = self.split_f32x8(b);
+        self.combine_f32x4(self.add_f32x4(a0, b0), self.add_f32x4(a1, b1))
+    }
+    #[inline(always)]
+    fn sub_f32x8(self, a: f32x8<Self>, b: f32x8<Self>) -> f32x8<Self> {
+        let (a0, a1) = self.split_f32x8(a);
+        let (b0, b1) = self.split_f32x8(b);
+        self.combine_f32x4(self.sub_f32x4(a0, b0), self.sub_f32x4(a1, b1))
+    }
+    #[inline(always)]
+    fn mul_f32x8(self, a: f32x8<Self>, b: f32x8<Self>) -> f32x8<Self> {
+        let (a0, a1) = self.split_f32x8(a);
+        let (b0, b1) = self.split_f32x8(b);
+        self.combine_f32x4(self.mul_f32x4(a0, b0), self.mul_f32x4(a1, b1))
+    }
+    #[inline(always)]
+    fn div_f32x8(self, a: f32x8<Self>, b: f32x8<Self>) -> f32x8<Self> {
+        let (a0, a1) = self.split_f32x8(a);
+        let (b0, b1) = self.split_f32x8(b);
+        self.combine_f32x4(self.div_f32x4(a0, b0), self.div_f32x4(a1, b1))
+    }
+    #[inline(always)]
+    fn copysign_f32x8(self, a: f32x8<Self>, b: f32x8<Self>) -> f32x8<Self> {
+        let (a0, a1) = self.split_f32x8(a);
+        let (b0, b1) = self.split_f32x8(b);
+        self.combine_f32x4(self.copysign_f32x4(a0, b0), self.copysign_f32x4(a1, b1))
+    }
+    #[inline(always)]
+    fn simd_eq_f32x8(self, a: f32x8<Self>, b: f32x8<Self>) -> mask32x8<Self> {
+        let (a0, a1) = self.split_f32x8(a);
+        let (b0, b1) = self.split_f32x8(b);
+        self.combine_mask32x4(self.simd_eq_f32x4(a0, b0), self.simd_eq_f32x4(a1, b1))
+    }
+    #[inline(always)]
+    fn simd_lt_f32x8(self, a: f32x8<Self>, b: f32x8<Self>) -> mask32x8<Self> {
+        let (a0, a1) = self.split_f32x8(a);
+        let (b0, b1) = self.split_f32x8(b);
+        self.combine_mask32x4(self.simd_lt_f32x4(a0, b0), self.simd_lt_f32x4(a1, b1))
+    }
+    #[inline(always)]
+    fn simd_le_f32x8(self, a: f32x8<Self>, b: f32x8<Self>) -> mask32x8<Self> {
+        let (a0, a1) = self.split_f32x8(a);
+        let (b0, b1) = self.split_f32x8(b);
+        self.combine_mask32x4(self.simd_le_f32x4(a0, b0), self.simd_le_f32x4(a1, b1))
+    }
+    #[inline(always)]
+    fn simd_ge_f32x8(self, a: f32x8<Self>, b: f32x8<Self>) -> mask32x8<Self> {
+        let (a0, a1) = self.split_f32x8(a);
+        let (b0, b1) = self.split_f32x8(b);
+        self.combine_mask32x4(self.simd_ge_f32x4(a0, b0), self.simd_ge_f32x4(a1, b1))
+    }
+    #[inline(always)]
+    fn simd_gt_f32x8(self, a: f32x8<Self>, b: f32x8<Self>) -> mask32x8<Self> {
+        let (a0, a1) = self.split_f32x8(a);
+        let (b0, b1) = self.split_f32x8(b);
+        self.combine_mask32x4(self.simd_gt_f32x4(a0, b0), self.simd_gt_f32x4(a1, b1))
+    }
+    #[inline(always)]
+    fn zip_f32x8(self, a: f32x8<Self>, b: f32x8<Self>) -> (f32x8<Self>, f32x8<Self>) {
+        let (a0, a1) = self.split_f32x8(a);
+        let (b0, b1) = self.split_f32x8(b);
+        let (c00, c01) = self.zip_f32x4(a0, b0);
+        let (c10, c11) = self.zip_f32x4(a1, b1);
+        (self.combine_f32x4(c00, c01), self.combine_f32x4(c10, c11))
+    }
+    #[inline(always)]
+    fn unzip_f32x8(self, a: f32x8<Self>, b: f32x8<Self>) -> (f32x8<Self>, f32x8<Self>) {
+        let (a0, a1) = self.split_f32x8(a);
+        let (b0, b1) = self.split_f32x8(b);
+        let (c00, c01) = self.unzip_f32x4(a0, a1);
+        let (c10, c11) = self.unzip_f32x4(b0, b1);
+        (self.combine_f32x4(c00, c10), self.combine_f32x4(c01, c11))
+    }
+    #[inline(always)]
+    fn max_f32x8(self, a: f32x8<Self>, b: f32x8<Self>) -> f32x8<Self> {
+        let (a0, a1) = self.split_f32x8(a);
+        let (b0, b1) = self.split_f32x8(b);
+        self.combine_f32x4(self.max_f32x4(a0, b0), self.max_f32x4(a1, b1))
+    }
+    #[inline(always)]
+    fn max_precise_f32x8(self, a: f32x8<Self>, b: f32x8<Self>) -> f32x8<Self> {
+        let (a0, a1) = self.split_f32x8(a);
+        let (b0, b1) = self.split_f32x8(b);
+        self.combine_f32x4(
+            self.max_precise_f32x4(a0, b0),
+            self.max_precise_f32x4(a1, b1),
+        )
+    }
+    #[inline(always)]
+    fn min_f32x8(self, a: f32x8<Self>, b: f32x8<Self>) -> f32x8<Self> {
+        let (a0, a1) = self.split_f32x8(a);
+        let (b0, b1) = self.split_f32x8(b);
+        self.combine_f32x4(self.min_f32x4(a0, b0), self.min_f32x4(a1, b1))
+    }
+    #[inline(always)]
+    fn min_precise_f32x8(self, a: f32x8<Self>, b: f32x8<Self>) -> f32x8<Self> {
+        let (a0, a1) = self.split_f32x8(a);
+        let (b0, b1) = self.split_f32x8(b);
+        self.combine_f32x4(
+            self.min_precise_f32x4(a0, b0),
+            self.min_precise_f32x4(a1, b1),
+        )
+    }
+    #[inline(always)]
+    fn madd_f32x8(self, a: f32x8<Self>, b: f32x8<Self>, c: f32x8<Self>) -> f32x8<Self> {
+        let (a0, a1) = self.split_f32x8(a);
+        let (b0, b1) = self.split_f32x8(b);
+        let (c0, c1) = self.split_f32x8(c);
+        self.combine_f32x4(self.madd_f32x4(a0, b0, c0), self.madd_f32x4(a1, b1, c1))
+    }
+    #[inline(always)]
+    fn floor_f32x8(self, a: f32x8<Self>) -> f32x8<Self> {
+        let (a0, a1) = self.split_f32x8(a);
+        self.combine_f32x4(self.floor_f32x4(a0), self.floor_f32x4(a1))
+    }
+    #[inline(always)]
+    fn select_f32x8(
+        self,
+        a: mask32x8<Self>,
+        b: f32x8<Self>,
+        c: f32x8<Self>,
+    ) -> f32x8<Self> {
+        let (a0, a1) = self.split_mask32x8(a);
+        let (b0, b1) = self.split_f32x8(b);
+        let (c0, c1) = self.split_f32x8(c);
+        self.combine_f32x4(self.select_f32x4(a0, b0, c0), self.select_f32x4(a1, b1, c1))
+    }
+    #[inline(always)]
+    fn split_f32x8(self, a: f32x8<Self>) -> (f32x4<Self>, f32x4<Self>) {
+        let mut b0 = [0.0; 4usize];
+        let mut b1 = [0.0; 4usize];
+        b0.copy_from_slice(&a.val[0..4usize]);
+        b1.copy_from_slice(&a.val[4usize..8usize]);
+        (b0.simd_into(self), b1.simd_into(self))
+    }
+    #[inline(always)]
+    fn cvt_u32_f32x8(self, a: f32x8<Self>) -> u32x8<Self> {
+        let (a0, a1) = self.split_f32x8(a);
+        self.combine_u32x4(self.cvt_u32_f32x4(a0), self.cvt_u32_f32x4(a1))
+    }
+    #[inline(always)]
+    fn splat_i8x32(self, a: i8) -> i8x32<Self> {
+        let half = self.splat_i8x16(a);
+        self.combine_i8x16(half, half)
+    }
+    #[inline(always)]
+    fn not_i8x32(self, a: i8x32<Self>) -> i8x32<Self> {
+        let (a0, a1) = self.split_i8x32(a);
+        self.combine_i8x16(self.not_i8x16(a0), self.not_i8x16(a1))
+    }
+    #[inline(always)]
+    fn add_i8x32(self, a: i8x32<Self>, b: i8x32<Self>) -> i8x32<Self> {
+        let (a0, a1) = self.split_i8x32(a);
+        let (b0, b1) = self.split_i8x32(b);
+        self.combine_i8x16(self.add_i8x16(a0, b0), self.add_i8x16(a1, b1))
+    }
+    #[inline(always)]
+    fn sub_i8x32(self, a: i8x32<Self>, b: i8x32<Self>) -> i8x32<Self> {
+        let (a0, a1) = self.split_i8x32(a);
+        let (b0, b1) = self.split_i8x32(b);
+        self.combine_i8x16(self.sub_i8x16(a0, b0), self.sub_i8x16(a1, b1))
+    }
+    #[inline(always)]
+    fn mul_i8x32(self, a: i8x32<Self>, b: i8x32<Self>) -> i8x32<Self> {
+        let (a0, a1) = self.split_i8x32(a);
+        let (b0, b1) = self.split_i8x32(b);
+        self.combine_i8x16(self.mul_i8x16(a0, b0), self.mul_i8x16(a1, b1))
+    }
+    #[inline(always)]
+    fn and_i8x32(self, a: i8x32<Self>, b: i8x32<Self>) -> i8x32<Self> {
+        let (a0, a1) = self.split_i8x32(a);
+        let (b0, b1) = self.split_i8x32(b);
+        self.combine_i8x16(self.and_i8x16(a0, b0), self.and_i8x16(a1, b1))
+    }
+    #[inline(always)]
+    fn or_i8x32(self, a: i8x32<Self>, b: i8x32<Self>) -> i8x32<Self> {
+        let (a0, a1) = self.split_i8x32(a);
+        let (b0, b1) = self.split_i8x32(b);
+        self.combine_i8x16(self.or_i8x16(a0, b0), self.or_i8x16(a1, b1))
+    }
+    #[inline(always)]
+    fn xor_i8x32(self, a: i8x32<Self>, b: i8x32<Self>) -> i8x32<Self> {
+        let (a0, a1) = self.split_i8x32(a);
+        let (b0, b1) = self.split_i8x32(b);
+        self.combine_i8x16(self.xor_i8x16(a0, b0), self.xor_i8x16(a1, b1))
+    }
+    #[inline(always)]
+    fn simd_eq_i8x32(self, a: i8x32<Self>, b: i8x32<Self>) -> mask8x32<Self> {
+        let (a0, a1) = self.split_i8x32(a);
+        let (b0, b1) = self.split_i8x32(b);
+        self.combine_mask8x16(self.simd_eq_i8x16(a0, b0), self.simd_eq_i8x16(a1, b1))
+    }
+    #[inline(always)]
+    fn simd_lt_i8x32(self, a: i8x32<Self>, b: i8x32<Self>) -> mask8x32<Self> {
+        let (a0, a1) = self.split_i8x32(a);
+        let (b0, b1) = self.split_i8x32(b);
+        self.combine_mask8x16(self.simd_lt_i8x16(a0, b0), self.simd_lt_i8x16(a1, b1))
+    }
+    #[inline(always)]
+    fn simd_le_i8x32(self, a: i8x32<Self>, b: i8x32<Self>) -> mask8x32<Self> {
+        let (a0, a1) = self.split_i8x32(a);
+        let (b0, b1) = self.split_i8x32(b);
+        self.combine_mask8x16(self.simd_le_i8x16(a0, b0), self.simd_le_i8x16(a1, b1))
+    }
+    #[inline(always)]
+    fn simd_ge_i8x32(self, a: i8x32<Self>, b: i8x32<Self>) -> mask8x32<Self> {
+        let (a0, a1) = self.split_i8x32(a);
+        let (b0, b1) = self.split_i8x32(b);
+        self.combine_mask8x16(self.simd_ge_i8x16(a0, b0), self.simd_ge_i8x16(a1, b1))
+    }
+    #[inline(always)]
+    fn simd_gt_i8x32(self, a: i8x32<Self>, b: i8x32<Self>) -> mask8x32<Self> {
+        let (a0, a1) = self.split_i8x32(a);
+        let (b0, b1) = self.split_i8x32(b);
+        self.combine_mask8x16(self.simd_gt_i8x16(a0, b0), self.simd_gt_i8x16(a1, b1))
+    }
+    #[inline(always)]
+    fn zip_i8x32(self, a: i8x32<Self>, b: i8x32<Self>) -> (i8x32<Self>, i8x32<Self>) {
+        let (a0, a1) = self.split_i8x32(a);
+        let (b0, b1) = self.split_i8x32(b);
+        let (c00, c01) = self.zip_i8x16(a0, b0);
+        let (c10, c11) = self.zip_i8x16(a1, b1);
+        (self.combine_i8x16(c00, c01), self.combine_i8x16(c10, c11))
+    }
+    #[inline(always)]
+    fn unzip_i8x32(self, a: i8x32<Self>, b: i8x32<Self>) -> (i8x32<Self>, i8x32<Self>) {
+        let (a0, a1) = self.split_i8x32(a);
+        let (b0, b1) = self.split_i8x32(b);
+        let (c00, c01) = self.unzip_i8x16(a0, a1);
+        let (c10, c11) = self.unzip_i8x16(b0, b1);
+        (self.combine_i8x16(c00, c10), self.combine_i8x16(c01, c11))
+    }
+    #[inline(always)]
+    fn select_i8x32(
+        self,
+        a: mask8x32<Self>,
+        b: i8x32<Self>,
+        c: i8x32<Self>,
+    ) -> i8x32<Self> {
+        let (a0, a1) = self.split_mask8x32(a);
+        let (b0, b1) = self.split_i8x32(b);
+        let (c0, c1) = self.split_i8x32(c);
+        self.combine_i8x16(self.select_i8x16(a0, b0, c0), self.select_i8x16(a1, b1, c1))
+    }
+    #[inline(always)]
+    fn split_i8x32(self, a: i8x32<Self>) -> (i8x16<Self>, i8x16<Self>) {
+        let mut b0 = [0; 16usize];
+        let mut b1 = [0; 16usize];
+        b0.copy_from_slice(&a.val[0..16usize]);
+        b1.copy_from_slice(&a.val[16usize..32usize]);
+        (b0.simd_into(self), b1.simd_into(self))
+    }
+    #[inline(always)]
+    fn splat_u8x32(self, a: u8) -> u8x32<Self> {
+        let half = self.splat_u8x16(a);
+        self.combine_u8x16(half, half)
+    }
+    #[inline(always)]
+    fn not_u8x32(self, a: u8x32<Self>) -> u8x32<Self> {
+        let (a0, a1) = self.split_u8x32(a);
+        self.combine_u8x16(self.not_u8x16(a0), self.not_u8x16(a1))
+    }
+    #[inline(always)]
+    fn add_u8x32(self, a: u8x32<Self>, b: u8x32<Self>) -> u8x32<Self> {
+        let (a0, a1) = self.split_u8x32(a);
+        let (b0, b1) = self.split_u8x32(b);
+        self.combine_u8x16(self.add_u8x16(a0, b0), self.add_u8x16(a1, b1))
+    }
+    #[inline(always)]
+    fn sub_u8x32(self, a: u8x32<Self>, b: u8x32<Self>) -> u8x32<Self> {
+        let (a0, a1) = self.split_u8x32(a);
+        let (b0, b1) = self.split_u8x32(b);
+        self.combine_u8x16(self.sub_u8x16(a0, b0), self.sub_u8x16(a1, b1))
+    }
+    #[inline(always)]
+    fn mul_u8x32(self, a: u8x32<Self>, b: u8x32<Self>) -> u8x32<Self> {
+        let (a0, a1) = self.split_u8x32(a);
+        let (b0, b1) = self.split_u8x32(b);
+        self.combine_u8x16(self.mul_u8x16(a0, b0), self.mul_u8x16(a1, b1))
+    }
+    #[inline(always)]
+    fn and_u8x32(self, a: u8x32<Self>, b: u8x32<Self>) -> u8x32<Self> {
+        let (a0, a1) = self.split_u8x32(a);
+        let (b0, b1) = self.split_u8x32(b);
+        self.combine_u8x16(self.and_u8x16(a0, b0), self.and_u8x16(a1, b1))
+    }
+    #[inline(always)]
+    fn or_u8x32(self, a: u8x32<Self>, b: u8x32<Self>) -> u8x32<Self> {
+        let (a0, a1) = self.split_u8x32(a);
+        let (b0, b1) = self.split_u8x32(b);
+        self.combine_u8x16(self.or_u8x16(a0, b0), self.or_u8x16(a1, b1))
+    }
+    #[inline(always)]
+    fn xor_u8x32(self, a: u8x32<Self>, b: u8x32<Self>) -> u8x32<Self> {
+        let (a0, a1) = self.split_u8x32(a);
+        let (b0, b1) = self.split_u8x32(b);
+        self.combine_u8x16(self.xor_u8x16(a0, b0), self.xor_u8x16(a1, b1))
+    }
+    #[inline(always)]
+    fn simd_eq_u8x32(self, a: u8x32<Self>, b: u8x32<Self>) -> mask8x32<Self> {
+        let (a0, a1) = self.split_u8x32(a);
+        let (b0, b1) = self.split_u8x32(b);
+        self.combine_mask8x16(self.simd_eq_u8x16(a0, b0), self.simd_eq_u8x16(a1, b1))
+    }
+    #[inline(always)]
+    fn simd_lt_u8x32(self, a: u8x32<Self>, b: u8x32<Self>) -> mask8x32<Self> {
+        let (a0, a1) = self.split_u8x32(a);
+        let (b0, b1) = self.split_u8x32(b);
+        self.combine_mask8x16(self.simd_lt_u8x16(a0, b0), self.simd_lt_u8x16(a1, b1))
+    }
+    #[inline(always)]
+    fn simd_le_u8x32(self, a: u8x32<Self>, b: u8x32<Self>) -> mask8x32<Self> {
+        let (a0, a1) = self.split_u8x32(a);
+        let (b0, b1) = self.split_u8x32(b);
+        self.combine_mask8x16(self.simd_le_u8x16(a0, b0), self.simd_le_u8x16(a1, b1))
+    }
+    #[inline(always)]
+    fn simd_ge_u8x32(self, a: u8x32<Self>, b: u8x32<Self>) -> mask8x32<Self> {
+        let (a0, a1) = self.split_u8x32(a);
+        let (b0, b1) = self.split_u8x32(b);
+        self.combine_mask8x16(self.simd_ge_u8x16(a0, b0), self.simd_ge_u8x16(a1, b1))
+    }
+    #[inline(always)]
+    fn simd_gt_u8x32(self, a: u8x32<Self>, b: u8x32<Self>) -> mask8x32<Self> {
+        let (a0, a1) = self.split_u8x32(a);
+        let (b0, b1) = self.split_u8x32(b);
+        self.combine_mask8x16(self.simd_gt_u8x16(a0, b0), self.simd_gt_u8x16(a1, b1))
+    }
+    #[inline(always)]
+    fn zip_u8x32(self, a: u8x32<Self>, b: u8x32<Self>) -> (u8x32<Self>, u8x32<Self>) {
+        let (a0, a1) = self.split_u8x32(a);
+        let (b0, b1) = self.split_u8x32(b);
+        let (c00, c01) = self.zip_u8x16(a0, b0);
+        let (c10, c11) = self.zip_u8x16(a1, b1);
+        (self.combine_u8x16(c00, c01), self.combine_u8x16(c10, c11))
+    }
+    #[inline(always)]
+    fn unzip_u8x32(self, a: u8x32<Self>, b: u8x32<Self>) -> (u8x32<Self>, u8x32<Self>) {
+        let (a0, a1) = self.split_u8x32(a);
+        let (b0, b1) = self.split_u8x32(b);
+        let (c00, c01) = self.unzip_u8x16(a0, a1);
+        let (c10, c11) = self.unzip_u8x16(b0, b1);
+        (self.combine_u8x16(c00, c10), self.combine_u8x16(c01, c11))
+    }
+    #[inline(always)]
+    fn select_u8x32(
+        self,
+        a: mask8x32<Self>,
+        b: u8x32<Self>,
+        c: u8x32<Self>,
+    ) -> u8x32<Self> {
+        let (a0, a1) = self.split_mask8x32(a);
+        let (b0, b1) = self.split_u8x32(b);
+        let (c0, c1) = self.split_u8x32(c);
+        self.combine_u8x16(self.select_u8x16(a0, b0, c0), self.select_u8x16(a1, b1, c1))
+    }
+    #[inline(always)]
+    fn split_u8x32(self, a: u8x32<Self>) -> (u8x16<Self>, u8x16<Self>) {
+        let mut b0 = [0; 16usize];
+        let mut b1 = [0; 16usize];
+        b0.copy_from_slice(&a.val[0..16usize]);
+        b1.copy_from_slice(&a.val[16usize..32usize]);
+        (b0.simd_into(self), b1.simd_into(self))
+    }
+    #[inline(always)]
+    fn splat_mask8x32(self, a: i8) -> mask8x32<Self> {
+        let half = self.splat_mask8x16(a);
+        self.combine_mask8x16(half, half)
+    }
+    #[inline(always)]
+    fn not_mask8x32(self, a: mask8x32<Self>) -> mask8x32<Self> {
+        let (a0, a1) = self.split_mask8x32(a);
+        self.combine_mask8x16(self.not_mask8x16(a0), self.not_mask8x16(a1))
+    }
+    #[inline(always)]
+    fn and_mask8x32(self, a: mask8x32<Self>, b: mask8x32<Self>) -> mask8x32<Self> {
+        let (a0, a1) = self.split_mask8x32(a);
+        let (b0, b1) = self.split_mask8x32(b);
+        self.combine_mask8x16(self.and_mask8x16(a0, b0), self.and_mask8x16(a1, b1))
+    }
+    #[inline(always)]
+    fn or_mask8x32(self, a: mask8x32<Self>, b: mask8x32<Self>) -> mask8x32<Self> {
+        let (a0, a1) = self.split_mask8x32(a);
+        let (b0, b1) = self.split_mask8x32(b);
+        self.combine_mask8x16(self.or_mask8x16(a0, b0), self.or_mask8x16(a1, b1))
+    }
+    #[inline(always)]
+    fn xor_mask8x32(self, a: mask8x32<Self>, b: mask8x32<Self>) -> mask8x32<Self> {
+        let (a0, a1) = self.split_mask8x32(a);
+        let (b0, b1) = self.split_mask8x32(b);
+        self.combine_mask8x16(self.xor_mask8x16(a0, b0), self.xor_mask8x16(a1, b1))
+    }
+    #[inline(always)]
+    fn select_mask8x32(
+        self,
+        a: mask8x32<Self>,
+        b: mask8x32<Self>,
+        c: mask8x32<Self>,
+    ) -> mask8x32<Self> {
+        let (a0, a1) = self.split_mask8x32(a);
+        let (b0, b1) = self.split_mask8x32(b);
+        let (c0, c1) = self.split_mask8x32(c);
+        self.combine_mask8x16(
+            self.select_mask8x16(a0, b0, c0),
+            self.select_mask8x16(a1, b1, c1),
+        )
+    }
+    #[inline(always)]
+    fn zip_mask8x32(
+        self,
+        a: mask8x32<Self>,
+        b: mask8x32<Self>,
+    ) -> (mask8x32<Self>, mask8x32<Self>) {
+        let (a0, a1) = self.split_mask8x32(a);
+        let (b0, b1) = self.split_mask8x32(b);
+        let (c00, c01) = self.zip_mask8x16(a0, b0);
+        let (c10, c11) = self.zip_mask8x16(a1, b1);
+        (self.combine_mask8x16(c00, c01), self.combine_mask8x16(c10, c11))
+    }
+    #[inline(always)]
+    fn unzip_mask8x32(
+        self,
+        a: mask8x32<Self>,
+        b: mask8x32<Self>,
+    ) -> (mask8x32<Self>, mask8x32<Self>) {
+        let (a0, a1) = self.split_mask8x32(a);
+        let (b0, b1) = self.split_mask8x32(b);
+        let (c00, c01) = self.unzip_mask8x16(a0, a1);
+        let (c10, c11) = self.unzip_mask8x16(b0, b1);
+        (self.combine_mask8x16(c00, c10), self.combine_mask8x16(c01, c11))
+    }
+    #[inline(always)]
+    fn simd_eq_mask8x32(self, a: mask8x32<Self>, b: mask8x32<Self>) -> mask8x32<Self> {
+        let (a0, a1) = self.split_mask8x32(a);
+        let (b0, b1) = self.split_mask8x32(b);
+        self.combine_mask8x16(
+            self.simd_eq_mask8x16(a0, b0),
+            self.simd_eq_mask8x16(a1, b1),
+        )
+    }
+    #[inline(always)]
+    fn split_mask8x32(self, a: mask8x32<Self>) -> (mask8x16<Self>, mask8x16<Self>) {
+        let mut b0 = [0; 16usize];
+        let mut b1 = [0; 16usize];
+        b0.copy_from_slice(&a.val[0..16usize]);
+        b1.copy_from_slice(&a.val[16usize..32usize]);
+        (b0.simd_into(self), b1.simd_into(self))
+    }
+    #[inline(always)]
+    fn splat_i16x16(self, a: i16) -> i16x16<Self> {
+        let half = self.splat_i16x8(a);
+        self.combine_i16x8(half, half)
+    }
+    #[inline(always)]
+    fn not_i16x16(self, a: i16x16<Self>) -> i16x16<Self> {
+        let (a0, a1) = self.split_i16x16(a);
+        self.combine_i16x8(self.not_i16x8(a0), self.not_i16x8(a1))
+    }
+    #[inline(always)]
+    fn add_i16x16(self, a: i16x16<Self>, b: i16x16<Self>) -> i16x16<Self> {
+        let (a0, a1) = self.split_i16x16(a);
+        let (b0, b1) = self.split_i16x16(b);
+        self.combine_i16x8(self.add_i16x8(a0, b0), self.add_i16x8(a1, b1))
+    }
+    #[inline(always)]
+    fn sub_i16x16(self, a: i16x16<Self>, b: i16x16<Self>) -> i16x16<Self> {
+        let (a0, a1) = self.split_i16x16(a);
+        let (b0, b1) = self.split_i16x16(b);
+        self.combine_i16x8(self.sub_i16x8(a0, b0), self.sub_i16x8(a1, b1))
+    }
+    #[inline(always)]
+    fn mul_i16x16(self, a: i16x16<Self>, b: i16x16<Self>) -> i16x16<Self> {
+        let (a0, a1) = self.split_i16x16(a);
+        let (b0, b1) = self.split_i16x16(b);
+        self.combine_i16x8(self.mul_i16x8(a0, b0), self.mul_i16x8(a1, b1))
+    }
+    #[inline(always)]
+    fn and_i16x16(self, a: i16x16<Self>, b: i16x16<Self>) -> i16x16<Self> {
+        let (a0, a1) = self.split_i16x16(a);
+        let (b0, b1) = self.split_i16x16(b);
+        self.combine_i16x8(self.and_i16x8(a0, b0), self.and_i16x8(a1, b1))
+    }
+    #[inline(always)]
+    fn or_i16x16(self, a: i16x16<Self>, b: i16x16<Self>) -> i16x16<Self> {
+        let (a0, a1) = self.split_i16x16(a);
+        let (b0, b1) = self.split_i16x16(b);
+        self.combine_i16x8(self.or_i16x8(a0, b0), self.or_i16x8(a1, b1))
+    }
+    #[inline(always)]
+    fn xor_i16x16(self, a: i16x16<Self>, b: i16x16<Self>) -> i16x16<Self> {
+        let (a0, a1) = self.split_i16x16(a);
+        let (b0, b1) = self.split_i16x16(b);
+        self.combine_i16x8(self.xor_i16x8(a0, b0), self.xor_i16x8(a1, b1))
+    }
+    #[inline(always)]
+    fn simd_eq_i16x16(self, a: i16x16<Self>, b: i16x16<Self>) -> mask16x16<Self> {
+        let (a0, a1) = self.split_i16x16(a);
+        let (b0, b1) = self.split_i16x16(b);
+        self.combine_mask16x8(self.simd_eq_i16x8(a0, b0), self.simd_eq_i16x8(a1, b1))
+    }
+    #[inline(always)]
+    fn simd_lt_i16x16(self, a: i16x16<Self>, b: i16x16<Self>) -> mask16x16<Self> {
+        let (a0, a1) = self.split_i16x16(a);
+        let (b0, b1) = self.split_i16x16(b);
+        self.combine_mask16x8(self.simd_lt_i16x8(a0, b0), self.simd_lt_i16x8(a1, b1))
+    }
+    #[inline(always)]
+    fn simd_le_i16x16(self, a: i16x16<Self>, b: i16x16<Self>) -> mask16x16<Self> {
+        let (a0, a1) = self.split_i16x16(a);
+        let (b0, b1) = self.split_i16x16(b);
+        self.combine_mask16x8(self.simd_le_i16x8(a0, b0), self.simd_le_i16x8(a1, b1))
+    }
+    #[inline(always)]
+    fn simd_ge_i16x16(self, a: i16x16<Self>, b: i16x16<Self>) -> mask16x16<Self> {
+        let (a0, a1) = self.split_i16x16(a);
+        let (b0, b1) = self.split_i16x16(b);
+        self.combine_mask16x8(self.simd_ge_i16x8(a0, b0), self.simd_ge_i16x8(a1, b1))
+    }
+    #[inline(always)]
+    fn simd_gt_i16x16(self, a: i16x16<Self>, b: i16x16<Self>) -> mask16x16<Self> {
+        let (a0, a1) = self.split_i16x16(a);
+        let (b0, b1) = self.split_i16x16(b);
+        self.combine_mask16x8(self.simd_gt_i16x8(a0, b0), self.simd_gt_i16x8(a1, b1))
+    }
+    #[inline(always)]
+    fn zip_i16x16(
+        self,
+        a: i16x16<Self>,
+        b: i16x16<Self>,
+    ) -> (i16x16<Self>, i16x16<Self>) {
+        let (a0, a1) = self.split_i16x16(a);
+        let (b0, b1) = self.split_i16x16(b);
+        let (c00, c01) = self.zip_i16x8(a0, b0);
+        let (c10, c11) = self.zip_i16x8(a1, b1);
+        (self.combine_i16x8(c00, c01), self.combine_i16x8(c10, c11))
+    }
+    #[inline(always)]
+    fn unzip_i16x16(
+        self,
+        a: i16x16<Self>,
+        b: i16x16<Self>,
+    ) -> (i16x16<Self>, i16x16<Self>) {
+        let (a0, a1) = self.split_i16x16(a);
+        let (b0, b1) = self.split_i16x16(b);
+        let (c00, c01) = self.unzip_i16x8(a0, a1);
+        let (c10, c11) = self.unzip_i16x8(b0, b1);
+        (self.combine_i16x8(c00, c10), self.combine_i16x8(c01, c11))
+    }
+    #[inline(always)]
+    fn select_i16x16(
+        self,
+        a: mask16x16<Self>,
+        b: i16x16<Self>,
+        c: i16x16<Self>,
+    ) -> i16x16<Self> {
+        let (a0, a1) = self.split_mask16x16(a);
+        let (b0, b1) = self.split_i16x16(b);
+        let (c0, c1) = self.split_i16x16(c);
+        self.combine_i16x8(self.select_i16x8(a0, b0, c0), self.select_i16x8(a1, b1, c1))
+    }
+    #[inline(always)]
+    fn split_i16x16(self, a: i16x16<Self>) -> (i16x8<Self>, i16x8<Self>) {
+        let mut b0 = [0; 8usize];
+        let mut b1 = [0; 8usize];
+        b0.copy_from_slice(&a.val[0..8usize]);
+        b1.copy_from_slice(&a.val[8usize..16usize]);
+        (b0.simd_into(self), b1.simd_into(self))
+    }
+    #[inline(always)]
+    fn splat_u16x16(self, a: u16) -> u16x16<Self> {
+        let half = self.splat_u16x8(a);
+        self.combine_u16x8(half, half)
+    }
+    #[inline(always)]
+    fn not_u16x16(self, a: u16x16<Self>) -> u16x16<Self> {
+        let (a0, a1) = self.split_u16x16(a);
+        self.combine_u16x8(self.not_u16x8(a0), self.not_u16x8(a1))
+    }
+    #[inline(always)]
+    fn add_u16x16(self, a: u16x16<Self>, b: u16x16<Self>) -> u16x16<Self> {
+        let (a0, a1) = self.split_u16x16(a);
+        let (b0, b1) = self.split_u16x16(b);
+        self.combine_u16x8(self.add_u16x8(a0, b0), self.add_u16x8(a1, b1))
+    }
+    #[inline(always)]
+    fn sub_u16x16(self, a: u16x16<Self>, b: u16x16<Self>) -> u16x16<Self> {
+        let (a0, a1) = self.split_u16x16(a);
+        let (b0, b1) = self.split_u16x16(b);
+        self.combine_u16x8(self.sub_u16x8(a0, b0), self.sub_u16x8(a1, b1))
+    }
+    #[inline(always)]
+    fn mul_u16x16(self, a: u16x16<Self>, b: u16x16<Self>) -> u16x16<Self> {
+        let (a0, a1) = self.split_u16x16(a);
+        let (b0, b1) = self.split_u16x16(b);
+        self.combine_u16x8(self.mul_u16x8(a0, b0), self.mul_u16x8(a1, b1))
+    }
+    #[inline(always)]
+    fn and_u16x16(self, a: u16x16<Self>, b: u16x16<Self>) -> u16x16<Self> {
+        let (a0, a1) = self.split_u16x16(a);
+        let (b0, b1) = self.split_u16x16(b);
+        self.combine_u16x8(self.and_u16x8(a0, b0), self.and_u16x8(a1, b1))
+    }
+    #[inline(always)]
+    fn or_u16x16(self, a: u16x16<Self>, b: u16x16<Self>) -> u16x16<Self> {
+        let (a0, a1) = self.split_u16x16(a);
+        let (b0, b1) = self.split_u16x16(b);
+        self.combine_u16x8(self.or_u16x8(a0, b0), self.or_u16x8(a1, b1))
+    }
+    #[inline(always)]
+    fn xor_u16x16(self, a: u16x16<Self>, b: u16x16<Self>) -> u16x16<Self> {
+        let (a0, a1) = self.split_u16x16(a);
+        let (b0, b1) = self.split_u16x16(b);
+        self.combine_u16x8(self.xor_u16x8(a0, b0), self.xor_u16x8(a1, b1))
+    }
+    #[inline(always)]
+    fn simd_eq_u16x16(self, a: u16x16<Self>, b: u16x16<Self>) -> mask16x16<Self> {
+        let (a0, a1) = self.split_u16x16(a);
+        let (b0, b1) = self.split_u16x16(b);
+        self.combine_mask16x8(self.simd_eq_u16x8(a0, b0), self.simd_eq_u16x8(a1, b1))
+    }
+    #[inline(always)]
+    fn simd_lt_u16x16(self, a: u16x16<Self>, b: u16x16<Self>) -> mask16x16<Self> {
+        let (a0, a1) = self.split_u16x16(a);
+        let (b0, b1) = self.split_u16x16(b);
+        self.combine_mask16x8(self.simd_lt_u16x8(a0, b0), self.simd_lt_u16x8(a1, b1))
+    }
+    #[inline(always)]
+    fn simd_le_u16x16(self, a: u16x16<Self>, b: u16x16<Self>) -> mask16x16<Self> {
+        let (a0, a1) = self.split_u16x16(a);
+        let (b0, b1) = self.split_u16x16(b);
+        self.combine_mask16x8(self.simd_le_u16x8(a0, b0), self.simd_le_u16x8(a1, b1))
+    }
+    #[inline(always)]
+    fn simd_ge_u16x16(self, a: u16x16<Self>, b: u16x16<Self>) -> mask16x16<Self> {
+        let (a0, a1) = self.split_u16x16(a);
+        let (b0, b1) = self.split_u16x16(b);
+        self.combine_mask16x8(self.simd_ge_u16x8(a0, b0), self.simd_ge_u16x8(a1, b1))
+    }
+    #[inline(always)]
+    fn simd_gt_u16x16(self, a: u16x16<Self>, b: u16x16<Self>) -> mask16x16<Self> {
+        let (a0, a1) = self.split_u16x16(a);
+        let (b0, b1) = self.split_u16x16(b);
+        self.combine_mask16x8(self.simd_gt_u16x8(a0, b0), self.simd_gt_u16x8(a1, b1))
+    }
+    #[inline(always)]
+    fn zip_u16x16(
+        self,
+        a: u16x16<Self>,
+        b: u16x16<Self>,
+    ) -> (u16x16<Self>, u16x16<Self>) {
+        let (a0, a1) = self.split_u16x16(a);
+        let (b0, b1) = self.split_u16x16(b);
+        let (c00, c01) = self.zip_u16x8(a0, b0);
+        let (c10, c11) = self.zip_u16x8(a1, b1);
+        (self.combine_u16x8(c00, c01), self.combine_u16x8(c10, c11))
+    }
+    #[inline(always)]
+    fn unzip_u16x16(
+        self,
+        a: u16x16<Self>,
+        b: u16x16<Self>,
+    ) -> (u16x16<Self>, u16x16<Self>) {
+        let (a0, a1) = self.split_u16x16(a);
+        let (b0, b1) = self.split_u16x16(b);
+        let (c00, c01) = self.unzip_u16x8(a0, a1);
+        let (c10, c11) = self.unzip_u16x8(b0, b1);
+        (self.combine_u16x8(c00, c10), self.combine_u16x8(c01, c11))
+    }
+    #[inline(always)]
+    fn select_u16x16(
+        self,
+        a: mask16x16<Self>,
+        b: u16x16<Self>,
+        c: u16x16<Self>,
+    ) -> u16x16<Self> {
+        let (a0, a1) = self.split_mask16x16(a);
+        let (b0, b1) = self.split_u16x16(b);
+        let (c0, c1) = self.split_u16x16(c);
+        self.combine_u16x8(self.select_u16x8(a0, b0, c0), self.select_u16x8(a1, b1, c1))
+    }
+    #[inline(always)]
+    fn split_u16x16(self, a: u16x16<Self>) -> (u16x8<Self>, u16x8<Self>) {
+        let mut b0 = [0; 8usize];
+        let mut b1 = [0; 8usize];
+        b0.copy_from_slice(&a.val[0..8usize]);
+        b1.copy_from_slice(&a.val[8usize..16usize]);
+        (b0.simd_into(self), b1.simd_into(self))
+    }
+    #[inline(always)]
+    fn splat_mask16x16(self, a: i16) -> mask16x16<Self> {
+        let half = self.splat_mask16x8(a);
+        self.combine_mask16x8(half, half)
+    }
+    #[inline(always)]
+    fn not_mask16x16(self, a: mask16x16<Self>) -> mask16x16<Self> {
+        let (a0, a1) = self.split_mask16x16(a);
+        self.combine_mask16x8(self.not_mask16x8(a0), self.not_mask16x8(a1))
+    }
+    #[inline(always)]
+    fn and_mask16x16(self, a: mask16x16<Self>, b: mask16x16<Self>) -> mask16x16<Self> {
+        let (a0, a1) = self.split_mask16x16(a);
+        let (b0, b1) = self.split_mask16x16(b);
+        self.combine_mask16x8(self.and_mask16x8(a0, b0), self.and_mask16x8(a1, b1))
+    }
+    #[inline(always)]
+    fn or_mask16x16(self, a: mask16x16<Self>, b: mask16x16<Self>) -> mask16x16<Self> {
+        let (a0, a1) = self.split_mask16x16(a);
+        let (b0, b1) = self.split_mask16x16(b);
+        self.combine_mask16x8(self.or_mask16x8(a0, b0), self.or_mask16x8(a1, b1))
+    }
+    #[inline(always)]
+    fn xor_mask16x16(self, a: mask16x16<Self>, b: mask16x16<Self>) -> mask16x16<Self> {
+        let (a0, a1) = self.split_mask16x16(a);
+        let (b0, b1) = self.split_mask16x16(b);
+        self.combine_mask16x8(self.xor_mask16x8(a0, b0), self.xor_mask16x8(a1, b1))
+    }
+    #[inline(always)]
+    fn select_mask16x16(
+        self,
+        a: mask16x16<Self>,
+        b: mask16x16<Self>,
+        c: mask16x16<Self>,
+    ) -> mask16x16<Self> {
+        let (a0, a1) = self.split_mask16x16(a);
+        let (b0, b1) = self.split_mask16x16(b);
+        let (c0, c1) = self.split_mask16x16(c);
+        self.combine_mask16x8(
+            self.select_mask16x8(a0, b0, c0),
+            self.select_mask16x8(a1, b1, c1),
+        )
+    }
+    #[inline(always)]
+    fn zip_mask16x16(
+        self,
+        a: mask16x16<Self>,
+        b: mask16x16<Self>,
+    ) -> (mask16x16<Self>, mask16x16<Self>) {
+        let (a0, a1) = self.split_mask16x16(a);
+        let (b0, b1) = self.split_mask16x16(b);
+        let (c00, c01) = self.zip_mask16x8(a0, b0);
+        let (c10, c11) = self.zip_mask16x8(a1, b1);
+        (self.combine_mask16x8(c00, c01), self.combine_mask16x8(c10, c11))
+    }
+    #[inline(always)]
+    fn unzip_mask16x16(
+        self,
+        a: mask16x16<Self>,
+        b: mask16x16<Self>,
+    ) -> (mask16x16<Self>, mask16x16<Self>) {
+        let (a0, a1) = self.split_mask16x16(a);
+        let (b0, b1) = self.split_mask16x16(b);
+        let (c00, c01) = self.unzip_mask16x8(a0, a1);
+        let (c10, c11) = self.unzip_mask16x8(b0, b1);
+        (self.combine_mask16x8(c00, c10), self.combine_mask16x8(c01, c11))
+    }
+    #[inline(always)]
+    fn simd_eq_mask16x16(
+        self,
+        a: mask16x16<Self>,
+        b: mask16x16<Self>,
+    ) -> mask16x16<Self> {
+        let (a0, a1) = self.split_mask16x16(a);
+        let (b0, b1) = self.split_mask16x16(b);
+        self.combine_mask16x8(
+            self.simd_eq_mask16x8(a0, b0),
+            self.simd_eq_mask16x8(a1, b1),
+        )
+    }
+    #[inline(always)]
+    fn split_mask16x16(self, a: mask16x16<Self>) -> (mask16x8<Self>, mask16x8<Self>) {
+        let mut b0 = [0; 8usize];
+        let mut b1 = [0; 8usize];
+        b0.copy_from_slice(&a.val[0..8usize]);
+        b1.copy_from_slice(&a.val[8usize..16usize]);
+        (b0.simd_into(self), b1.simd_into(self))
+    }
+    #[inline(always)]
+    fn splat_i32x8(self, a: i32) -> i32x8<Self> {
+        let half = self.splat_i32x4(a);
+        self.combine_i32x4(half, half)
+    }
+    #[inline(always)]
+    fn not_i32x8(self, a: i32x8<Self>) -> i32x8<Self> {
+        let (a0, a1) = self.split_i32x8(a);
+        self.combine_i32x4(self.not_i32x4(a0), self.not_i32x4(a1))
+    }
+    #[inline(always)]
+    fn add_i32x8(self, a: i32x8<Self>, b: i32x8<Self>) -> i32x8<Self> {
+        let (a0, a1) = self.split_i32x8(a);
+        let (b0, b1) = self.split_i32x8(b);
+        self.combine_i32x4(self.add_i32x4(a0, b0), self.add_i32x4(a1, b1))
+    }
+    #[inline(always)]
+    fn sub_i32x8(self, a: i32x8<Self>, b: i32x8<Self>) -> i32x8<Self> {
+        let (a0, a1) = self.split_i32x8(a);
+        let (b0, b1) = self.split_i32x8(b);
+        self.combine_i32x4(self.sub_i32x4(a0, b0), self.sub_i32x4(a1, b1))
+    }
+    #[inline(always)]
+    fn mul_i32x8(self, a: i32x8<Self>, b: i32x8<Self>) -> i32x8<Self> {
+        let (a0, a1) = self.split_i32x8(a);
+        let (b0, b1) = self.split_i32x8(b);
+        self.combine_i32x4(self.mul_i32x4(a0, b0), self.mul_i32x4(a1, b1))
+    }
+    #[inline(always)]
+    fn and_i32x8(self, a: i32x8<Self>, b: i32x8<Self>) -> i32x8<Self> {
+        let (a0, a1) = self.split_i32x8(a);
+        let (b0, b1) = self.split_i32x8(b);
+        self.combine_i32x4(self.and_i32x4(a0, b0), self.and_i32x4(a1, b1))
+    }
+    #[inline(always)]
+    fn or_i32x8(self, a: i32x8<Self>, b: i32x8<Self>) -> i32x8<Self> {
+        let (a0, a1) = self.split_i32x8(a);
+        let (b0, b1) = self.split_i32x8(b);
+        self.combine_i32x4(self.or_i32x4(a0, b0), self.or_i32x4(a1, b1))
+    }
+    #[inline(always)]
+    fn xor_i32x8(self, a: i32x8<Self>, b: i32x8<Self>) -> i32x8<Self> {
+        let (a0, a1) = self.split_i32x8(a);
+        let (b0, b1) = self.split_i32x8(b);
+        self.combine_i32x4(self.xor_i32x4(a0, b0), self.xor_i32x4(a1, b1))
+    }
+    #[inline(always)]
+    fn simd_eq_i32x8(self, a: i32x8<Self>, b: i32x8<Self>) -> mask32x8<Self> {
+        let (a0, a1) = self.split_i32x8(a);
+        let (b0, b1) = self.split_i32x8(b);
+        self.combine_mask32x4(self.simd_eq_i32x4(a0, b0), self.simd_eq_i32x4(a1, b1))
+    }
+    #[inline(always)]
+    fn simd_lt_i32x8(self, a: i32x8<Self>, b: i32x8<Self>) -> mask32x8<Self> {
+        let (a0, a1) = self.split_i32x8(a);
+        let (b0, b1) = self.split_i32x8(b);
+        self.combine_mask32x4(self.simd_lt_i32x4(a0, b0), self.simd_lt_i32x4(a1, b1))
+    }
+    #[inline(always)]
+    fn simd_le_i32x8(self, a: i32x8<Self>, b: i32x8<Self>) -> mask32x8<Self> {
+        let (a0, a1) = self.split_i32x8(a);
+        let (b0, b1) = self.split_i32x8(b);
+        self.combine_mask32x4(self.simd_le_i32x4(a0, b0), self.simd_le_i32x4(a1, b1))
+    }
+    #[inline(always)]
+    fn simd_ge_i32x8(self, a: i32x8<Self>, b: i32x8<Self>) -> mask32x8<Self> {
+        let (a0, a1) = self.split_i32x8(a);
+        let (b0, b1) = self.split_i32x8(b);
+        self.combine_mask32x4(self.simd_ge_i32x4(a0, b0), self.simd_ge_i32x4(a1, b1))
+    }
+    #[inline(always)]
+    fn simd_gt_i32x8(self, a: i32x8<Self>, b: i32x8<Self>) -> mask32x8<Self> {
+        let (a0, a1) = self.split_i32x8(a);
+        let (b0, b1) = self.split_i32x8(b);
+        self.combine_mask32x4(self.simd_gt_i32x4(a0, b0), self.simd_gt_i32x4(a1, b1))
+    }
+    #[inline(always)]
+    fn zip_i32x8(self, a: i32x8<Self>, b: i32x8<Self>) -> (i32x8<Self>, i32x8<Self>) {
+        let (a0, a1) = self.split_i32x8(a);
+        let (b0, b1) = self.split_i32x8(b);
+        let (c00, c01) = self.zip_i32x4(a0, b0);
+        let (c10, c11) = self.zip_i32x4(a1, b1);
+        (self.combine_i32x4(c00, c01), self.combine_i32x4(c10, c11))
+    }
+    #[inline(always)]
+    fn unzip_i32x8(self, a: i32x8<Self>, b: i32x8<Self>) -> (i32x8<Self>, i32x8<Self>) {
+        let (a0, a1) = self.split_i32x8(a);
+        let (b0, b1) = self.split_i32x8(b);
+        let (c00, c01) = self.unzip_i32x4(a0, a1);
+        let (c10, c11) = self.unzip_i32x4(b0, b1);
+        (self.combine_i32x4(c00, c10), self.combine_i32x4(c01, c11))
+    }
+    #[inline(always)]
+    fn select_i32x8(
+        self,
+        a: mask32x8<Self>,
+        b: i32x8<Self>,
+        c: i32x8<Self>,
+    ) -> i32x8<Self> {
+        let (a0, a1) = self.split_mask32x8(a);
+        let (b0, b1) = self.split_i32x8(b);
+        let (c0, c1) = self.split_i32x8(c);
+        self.combine_i32x4(self.select_i32x4(a0, b0, c0), self.select_i32x4(a1, b1, c1))
+    }
+    #[inline(always)]
+    fn split_i32x8(self, a: i32x8<Self>) -> (i32x4<Self>, i32x4<Self>) {
+        let mut b0 = [0; 4usize];
+        let mut b1 = [0; 4usize];
+        b0.copy_from_slice(&a.val[0..4usize]);
+        b1.copy_from_slice(&a.val[4usize..8usize]);
+        (b0.simd_into(self), b1.simd_into(self))
+    }
+    #[inline(always)]
+    fn splat_u32x8(self, a: u32) -> u32x8<Self> {
+        let half = self.splat_u32x4(a);
+        self.combine_u32x4(half, half)
+    }
+    #[inline(always)]
+    fn not_u32x8(self, a: u32x8<Self>) -> u32x8<Self> {
+        let (a0, a1) = self.split_u32x8(a);
+        self.combine_u32x4(self.not_u32x4(a0), self.not_u32x4(a1))
+    }
+    #[inline(always)]
+    fn add_u32x8(self, a: u32x8<Self>, b: u32x8<Self>) -> u32x8<Self> {
+        let (a0, a1) = self.split_u32x8(a);
+        let (b0, b1) = self.split_u32x8(b);
+        self.combine_u32x4(self.add_u32x4(a0, b0), self.add_u32x4(a1, b1))
+    }
+    #[inline(always)]
+    fn sub_u32x8(self, a: u32x8<Self>, b: u32x8<Self>) -> u32x8<Self> {
+        let (a0, a1) = self.split_u32x8(a);
+        let (b0, b1) = self.split_u32x8(b);
+        self.combine_u32x4(self.sub_u32x4(a0, b0), self.sub_u32x4(a1, b1))
+    }
+    #[inline(always)]
+    fn mul_u32x8(self, a: u32x8<Self>, b: u32x8<Self>) -> u32x8<Self> {
+        let (a0, a1) = self.split_u32x8(a);
+        let (b0, b1) = self.split_u32x8(b);
+        self.combine_u32x4(self.mul_u32x4(a0, b0), self.mul_u32x4(a1, b1))
+    }
+    #[inline(always)]
+    fn and_u32x8(self, a: u32x8<Self>, b: u32x8<Self>) -> u32x8<Self> {
+        let (a0, a1) = self.split_u32x8(a);
+        let (b0, b1) = self.split_u32x8(b);
+        self.combine_u32x4(self.and_u32x4(a0, b0), self.and_u32x4(a1, b1))
+    }
+    #[inline(always)]
+    fn or_u32x8(self, a: u32x8<Self>, b: u32x8<Self>) -> u32x8<Self> {
+        let (a0, a1) = self.split_u32x8(a);
+        let (b0, b1) = self.split_u32x8(b);
+        self.combine_u32x4(self.or_u32x4(a0, b0), self.or_u32x4(a1, b1))
+    }
+    #[inline(always)]
+    fn xor_u32x8(self, a: u32x8<Self>, b: u32x8<Self>) -> u32x8<Self> {
+        let (a0, a1) = self.split_u32x8(a);
+        let (b0, b1) = self.split_u32x8(b);
+        self.combine_u32x4(self.xor_u32x4(a0, b0), self.xor_u32x4(a1, b1))
+    }
+    #[inline(always)]
+    fn simd_eq_u32x8(self, a: u32x8<Self>, b: u32x8<Self>) -> mask32x8<Self> {
+        let (a0, a1) = self.split_u32x8(a);
+        let (b0, b1) = self.split_u32x8(b);
+        self.combine_mask32x4(self.simd_eq_u32x4(a0, b0), self.simd_eq_u32x4(a1, b1))
+    }
+    #[inline(always)]
+    fn simd_lt_u32x8(self, a: u32x8<Self>, b: u32x8<Self>) -> mask32x8<Self> {
+        let (a0, a1) = self.split_u32x8(a);
+        let (b0, b1) = self.split_u32x8(b);
+        self.combine_mask32x4(self.simd_lt_u32x4(a0, b0), self.simd_lt_u32x4(a1, b1))
+    }
+    #[inline(always)]
+    fn simd_le_u32x8(self, a: u32x8<Self>, b: u32x8<Self>) -> mask32x8<Self> {
+        let (a0, a1) = self.split_u32x8(a);
+        let (b0, b1) = self.split_u32x8(b);
+        self.combine_mask32x4(self.simd_le_u32x4(a0, b0), self.simd_le_u32x4(a1, b1))
+    }
+    #[inline(always)]
+    fn simd_ge_u32x8(self, a: u32x8<Self>, b: u32x8<Self>) -> mask32x8<Self> {
+        let (a0, a1) = self.split_u32x8(a);
+        let (b0, b1) = self.split_u32x8(b);
+        self.combine_mask32x4(self.simd_ge_u32x4(a0, b0), self.simd_ge_u32x4(a1, b1))
+    }
+    #[inline(always)]
+    fn simd_gt_u32x8(self, a: u32x8<Self>, b: u32x8<Self>) -> mask32x8<Self> {
+        let (a0, a1) = self.split_u32x8(a);
+        let (b0, b1) = self.split_u32x8(b);
+        self.combine_mask32x4(self.simd_gt_u32x4(a0, b0), self.simd_gt_u32x4(a1, b1))
+    }
+    #[inline(always)]
+    fn zip_u32x8(self, a: u32x8<Self>, b: u32x8<Self>) -> (u32x8<Self>, u32x8<Self>) {
+        let (a0, a1) = self.split_u32x8(a);
+        let (b0, b1) = self.split_u32x8(b);
+        let (c00, c01) = self.zip_u32x4(a0, b0);
+        let (c10, c11) = self.zip_u32x4(a1, b1);
+        (self.combine_u32x4(c00, c01), self.combine_u32x4(c10, c11))
+    }
+    #[inline(always)]
+    fn unzip_u32x8(self, a: u32x8<Self>, b: u32x8<Self>) -> (u32x8<Self>, u32x8<Self>) {
+        let (a0, a1) = self.split_u32x8(a);
+        let (b0, b1) = self.split_u32x8(b);
+        let (c00, c01) = self.unzip_u32x4(a0, a1);
+        let (c10, c11) = self.unzip_u32x4(b0, b1);
+        (self.combine_u32x4(c00, c10), self.combine_u32x4(c01, c11))
+    }
+    #[inline(always)]
+    fn select_u32x8(
+        self,
+        a: mask32x8<Self>,
+        b: u32x8<Self>,
+        c: u32x8<Self>,
+    ) -> u32x8<Self> {
+        let (a0, a1) = self.split_mask32x8(a);
+        let (b0, b1) = self.split_u32x8(b);
+        let (c0, c1) = self.split_u32x8(c);
+        self.combine_u32x4(self.select_u32x4(a0, b0, c0), self.select_u32x4(a1, b1, c1))
+    }
+    #[inline(always)]
+    fn split_u32x8(self, a: u32x8<Self>) -> (u32x4<Self>, u32x4<Self>) {
+        let mut b0 = [0; 4usize];
+        let mut b1 = [0; 4usize];
+        b0.copy_from_slice(&a.val[0..4usize]);
+        b1.copy_from_slice(&a.val[4usize..8usize]);
+        (b0.simd_into(self), b1.simd_into(self))
+    }
+    #[inline(always)]
+    fn splat_mask32x8(self, a: i32) -> mask32x8<Self> {
+        let half = self.splat_mask32x4(a);
+        self.combine_mask32x4(half, half)
+    }
+    #[inline(always)]
+    fn not_mask32x8(self, a: mask32x8<Self>) -> mask32x8<Self> {
+        let (a0, a1) = self.split_mask32x8(a);
+        self.combine_mask32x4(self.not_mask32x4(a0), self.not_mask32x4(a1))
+    }
+    #[inline(always)]
+    fn and_mask32x8(self, a: mask32x8<Self>, b: mask32x8<Self>) -> mask32x8<Self> {
+        let (a0, a1) = self.split_mask32x8(a);
+        let (b0, b1) = self.split_mask32x8(b);
+        self.combine_mask32x4(self.and_mask32x4(a0, b0), self.and_mask32x4(a1, b1))
+    }
+    #[inline(always)]
+    fn or_mask32x8(self, a: mask32x8<Self>, b: mask32x8<Self>) -> mask32x8<Self> {
+        let (a0, a1) = self.split_mask32x8(a);
+        let (b0, b1) = self.split_mask32x8(b);
+        self.combine_mask32x4(self.or_mask32x4(a0, b0), self.or_mask32x4(a1, b1))
+    }
+    #[inline(always)]
+    fn xor_mask32x8(self, a: mask32x8<Self>, b: mask32x8<Self>) -> mask32x8<Self> {
+        let (a0, a1) = self.split_mask32x8(a);
+        let (b0, b1) = self.split_mask32x8(b);
+        self.combine_mask32x4(self.xor_mask32x4(a0, b0), self.xor_mask32x4(a1, b1))
+    }
+    #[inline(always)]
+    fn select_mask32x8(
+        self,
+        a: mask32x8<Self>,
+        b: mask32x8<Self>,
+        c: mask32x8<Self>,
+    ) -> mask32x8<Self> {
+        let (a0, a1) = self.split_mask32x8(a);
+        let (b0, b1) = self.split_mask32x8(b);
+        let (c0, c1) = self.split_mask32x8(c);
+        self.combine_mask32x4(
+            self.select_mask32x4(a0, b0, c0),
+            self.select_mask32x4(a1, b1, c1),
+        )
+    }
+    #[inline(always)]
+    fn zip_mask32x8(
+        self,
+        a: mask32x8<Self>,
+        b: mask32x8<Self>,
+    ) -> (mask32x8<Self>, mask32x8<Self>) {
+        let (a0, a1) = self.split_mask32x8(a);
+        let (b0, b1) = self.split_mask32x8(b);
+        let (c00, c01) = self.zip_mask32x4(a0, b0);
+        let (c10, c11) = self.zip_mask32x4(a1, b1);
+        (self.combine_mask32x4(c00, c01), self.combine_mask32x4(c10, c11))
+    }
+    #[inline(always)]
+    fn unzip_mask32x8(
+        self,
+        a: mask32x8<Self>,
+        b: mask32x8<Self>,
+    ) -> (mask32x8<Self>, mask32x8<Self>) {
+        let (a0, a1) = self.split_mask32x8(a);
+        let (b0, b1) = self.split_mask32x8(b);
+        let (c00, c01) = self.unzip_mask32x4(a0, a1);
+        let (c10, c11) = self.unzip_mask32x4(b0, b1);
+        (self.combine_mask32x4(c00, c10), self.combine_mask32x4(c01, c11))
+    }
+    #[inline(always)]
+    fn simd_eq_mask32x8(self, a: mask32x8<Self>, b: mask32x8<Self>) -> mask32x8<Self> {
+        let (a0, a1) = self.split_mask32x8(a);
+        let (b0, b1) = self.split_mask32x8(b);
+        self.combine_mask32x4(
+            self.simd_eq_mask32x4(a0, b0),
+            self.simd_eq_mask32x4(a1, b1),
+        )
+    }
+    #[inline(always)]
+    fn split_mask32x8(self, a: mask32x8<Self>) -> (mask32x4<Self>, mask32x4<Self>) {
+        let mut b0 = [0; 4usize];
+        let mut b1 = [0; 4usize];
+        b0.copy_from_slice(&a.val[0..4usize]);
+        b1.copy_from_slice(&a.val[4usize..8usize]);
+        (b0.simd_into(self), b1.simd_into(self))
+    }
+}
+impl<S: Simd> SimdFrom<v128, S> for f32x4<S> {
+    #[inline(always)]
+    fn simd_from(arch: v128, simd: S) -> Self {
+        Self {
+            val: unsafe { core::mem::transmute(arch) },
+            simd,
+        }
+    }
+}
+impl<S: Simd> From<f32x4<S>> for v128 {
+    #[inline(always)]
+    fn from(value: f32x4<S>) -> Self {
+        unsafe { core::mem::transmute(value.val) }
+    }
+}
+impl<S: Simd> SimdFrom<v128, S> for i8x16<S> {
+    #[inline(always)]
+    fn simd_from(arch: v128, simd: S) -> Self {
+        Self {
+            val: unsafe { core::mem::transmute(arch) },
+            simd,
+        }
+    }
+}
+impl<S: Simd> From<i8x16<S>> for v128 {
+    #[inline(always)]
+    fn from(value: i8x16<S>) -> Self {
+        unsafe { core::mem::transmute(value.val) }
+    }
+}
+impl<S: Simd> SimdFrom<v128, S> for u8x16<S> {
+    #[inline(always)]
+    fn simd_from(arch: v128, simd: S) -> Self {
+        Self {
+            val: unsafe { core::mem::transmute(arch) },
+            simd,
+        }
+    }
+}
+impl<S: Simd> From<u8x16<S>> for v128 {
+    #[inline(always)]
+    fn from(value: u8x16<S>) -> Self {
+        unsafe { core::mem::transmute(value.val) }
+    }
+}
+impl<S: Simd> SimdFrom<v128, S> for mask8x16<S> {
+    #[inline(always)]
+    fn simd_from(arch: v128, simd: S) -> Self {
+        Self {
+            val: unsafe { core::mem::transmute(arch) },
+            simd,
+        }
+    }
+}
+impl<S: Simd> From<mask8x16<S>> for v128 {
+    #[inline(always)]
+    fn from(value: mask8x16<S>) -> Self {
+        unsafe { core::mem::transmute(value.val) }
+    }
+}
+impl<S: Simd> SimdFrom<v128, S> for i16x8<S> {
+    #[inline(always)]
+    fn simd_from(arch: v128, simd: S) -> Self {
+        Self {
+            val: unsafe { core::mem::transmute(arch) },
+            simd,
+        }
+    }
+}
+impl<S: Simd> From<i16x8<S>> for v128 {
+    #[inline(always)]
+    fn from(value: i16x8<S>) -> Self {
+        unsafe { core::mem::transmute(value.val) }
+    }
+}
+impl<S: Simd> SimdFrom<v128, S> for u16x8<S> {
+    #[inline(always)]
+    fn simd_from(arch: v128, simd: S) -> Self {
+        Self {
+            val: unsafe { core::mem::transmute(arch) },
+            simd,
+        }
+    }
+}
+impl<S: Simd> From<u16x8<S>> for v128 {
+    #[inline(always)]
+    fn from(value: u16x8<S>) -> Self {
+        unsafe { core::mem::transmute(value.val) }
+    }
+}
+impl<S: Simd> SimdFrom<v128, S> for mask16x8<S> {
+    #[inline(always)]
+    fn simd_from(arch: v128, simd: S) -> Self {
+        Self {
+            val: unsafe { core::mem::transmute(arch) },
+            simd,
+        }
+    }
+}
+impl<S: Simd> From<mask16x8<S>> for v128 {
+    #[inline(always)]
+    fn from(value: mask16x8<S>) -> Self {
+        unsafe { core::mem::transmute(value.val) }
+    }
+}
+impl<S: Simd> SimdFrom<v128, S> for i32x4<S> {
+    #[inline(always)]
+    fn simd_from(arch: v128, simd: S) -> Self {
+        Self {
+            val: unsafe { core::mem::transmute(arch) },
+            simd,
+        }
+    }
+}
+impl<S: Simd> From<i32x4<S>> for v128 {
+    #[inline(always)]
+    fn from(value: i32x4<S>) -> Self {
+        unsafe { core::mem::transmute(value.val) }
+    }
+}
+impl<S: Simd> SimdFrom<v128, S> for u32x4<S> {
+    #[inline(always)]
+    fn simd_from(arch: v128, simd: S) -> Self {
+        Self {
+            val: unsafe { core::mem::transmute(arch) },
+            simd,
+        }
+    }
+}
+impl<S: Simd> From<u32x4<S>> for v128 {
+    #[inline(always)]
+    fn from(value: u32x4<S>) -> Self {
+        unsafe { core::mem::transmute(value.val) }
+    }
+}
+impl<S: Simd> SimdFrom<v128, S> for mask32x4<S> {
+    #[inline(always)]
+    fn simd_from(arch: v128, simd: S) -> Self {
+        Self {
+            val: unsafe { core::mem::transmute(arch) },
+            simd,
+        }
+    }
+}
+impl<S: Simd> From<mask32x4<S>> for v128 {
+    #[inline(always)]
+    fn from(value: mask32x4<S>) -> Self {
+        unsafe { core::mem::transmute(value.val) }
+    }
+}
+

--- a/fearless_simd/src/macros.rs
+++ b/fearless_simd/src/macros.rs
@@ -12,16 +12,24 @@ macro_rules! simd_dispatch {
     ) => {
         $( #[$meta] )* $vis
         fn $func(level: $crate::Level $(, $arg: $ty )*) $( -> $ret )? {
-            #[cfg(all(feature = "std", target_arch = "aarch64"))]
+            #[cfg(target_arch = "aarch64")]
             #[target_feature(enable = "neon")]
             #[inline]
             unsafe fn inner_neon(neon: $crate::aarch64::Neon $( , $arg: $ty )* ) $( -> $ret )? {
                 $inner( neon $( , $arg )* )
             }
+            #[cfg(target_arch = "wasm32")]
+            #[target_feature(enable = "simd128")]
+            #[inline]
+            unsafe fn inner_wasm_simd128(simd128: $crate::wasm32::WasmSimd128 $( , $arg: $ty )* ) $( -> $ret )? {
+                $inner( simd128 $( , $arg )* )
+            }
             match level {
                 Level::Fallback(fb) => $inner(fb $( , $arg )* ),
-                #[cfg(all(feature = "std", target_arch = "aarch64"))]
+                #[cfg(target_arch = "aarch64")]
                 Level::Neon(neon) => unsafe { inner_neon (neon $( , $arg )* ) }
+                #[cfg(target_arch = "wasm32")]
+                Level::WasmSimd128(wasm) => unsafe { inner_wasm_simd128 (wasm $( , $arg )* ) }
             }
         }
     };

--- a/fearless_simd/src/macros.rs
+++ b/fearless_simd/src/macros.rs
@@ -12,7 +12,7 @@ macro_rules! simd_dispatch {
     ) => {
         $( #[$meta] )* $vis
         fn $func(level: $crate::Level $(, $arg: $ty )*) $( -> $ret )? {
-            #[cfg(target_arch = "aarch64")]
+            #[cfg(all(feature = "std", target_arch = "aarch64"))]
             #[target_feature(enable = "neon")]
             #[inline]
             unsafe fn inner_neon(neon: $crate::aarch64::Neon $( , $arg: $ty )* ) $( -> $ret )? {
@@ -26,7 +26,7 @@ macro_rules! simd_dispatch {
             }
             match level {
                 Level::Fallback(fb) => $inner(fb $( , $arg )* ),
-                #[cfg(target_arch = "aarch64")]
+                #[cfg(all(feature = "std", target_arch = "aarch64"))]
                 Level::Neon(neon) => unsafe { inner_neon (neon $( , $arg )* ) }
                 #[cfg(target_arch = "wasm32")]
                 Level::WasmSimd128(wasm) => unsafe { inner_wasm_simd128 (wasm $( , $arg )* ) }
@@ -34,4 +34,3 @@ macro_rules! simd_dispatch {
         }
     };
 }
-

--- a/fearless_simd_gen/src/arch/mod.rs
+++ b/fearless_simd_gen/src/arch/mod.rs
@@ -3,6 +3,7 @@
 
 pub(crate) mod fallback;
 pub(crate) mod neon;
+pub(crate) mod wasm;
 
 use proc_macro2::TokenStream;
 

--- a/fearless_simd_gen/src/arch/wasm.rs
+++ b/fearless_simd_gen/src/arch/wasm.rs
@@ -1,0 +1,93 @@
+// Copyright 2025 the Fearless_SIMD Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use crate::arch::Arch;
+use crate::types::{ScalarType, VecType};
+use proc_macro2::{Ident, Span, TokenStream};
+use quote::quote;
+
+pub struct Wasm;
+
+fn translate_op(op: &str) -> Option<&'static str> {
+    Some(match op {
+        "abs" => "abs",
+        "neg" => "neg",
+        "floor" => "floor",
+        "sqrt" => "sqrt",
+        "add" => "add", // There is also a add_sat
+        "sub" => "sub", // There is also a sub_sat
+        "mul" => "mul",
+        "div" => "div",
+        "simd_eq" => "eq",
+        "simd_lt" => "lt",
+        "simd_le" => "le",
+        "simd_ge" => "ge",
+        "simd_gt" => "gt",
+        "not" => "not",
+        "and" => "and",
+        "or" => "or",
+        "xor" => "xor",
+        // TODO: With target-feature "relaxed-simd" this could be "relaxed_max".
+        "max" => "max",
+        // TODO: With target-feature "relaxed-simd" this could be "relaxed_min".
+        "min" => "min",
+        "max_precise" => "max",
+        "min_precise" => "min",
+        "splat" => "splat",
+        // TODO: Only target-feature "relaxed-simd" has "relaxed_madd".
+        _ => return None,
+    })
+}
+
+fn simple_intrinsic(name: &str, ty: &VecType) -> TokenStream {
+    let ty_prefix = Wasm.arch_ty(ty);
+    let ident = Ident::new(name, Span::call_site());
+    let combined_ident = Ident::new(
+        &format!("{}_{}", ty_prefix.to_string(), ident.to_string()),
+        Span::call_site(),
+    );
+    quote! { #combined_ident }
+}
+
+fn v128_intrinsic(name: &str) -> TokenStream {
+    let ty_prefix = Ident::new("v128", Span::call_site());
+    let ident = Ident::new(name, Span::call_site());
+    let combined_ident = Ident::new(
+        &format!("{}_{}", ty_prefix.to_string(), ident.to_string()),
+        Span::call_site(),
+    );
+    quote! { #combined_ident }
+}
+
+impl Arch for Wasm {
+    fn arch_ty(&self, ty: &VecType) -> TokenStream {
+        let scalar = match ty.scalar {
+            ScalarType::Float => "f",
+            ScalarType::Unsigned => "u",
+            ScalarType::Int | ScalarType::Mask => "i",
+        };
+        let name = format!("{}{}x{}", scalar, ty.scalar_bits, ty.len);
+        let ident = Ident::new(&name, Span::call_site());
+        quote! { #ident }
+    }
+
+    // expects args and return value in arch dialect
+    fn expr(&self, op: &str, ty: &VecType, args: &[TokenStream]) -> TokenStream {
+        if let Some(translated) = translate_op(op) {
+            let intrinsic = match translated {
+                "not" => v128_intrinsic(translated),
+                "and" => v128_intrinsic(translated),
+                "or" => v128_intrinsic(translated),
+                "xor" => v128_intrinsic(translated),
+                _ => simple_intrinsic(translated, ty),
+            };
+
+            quote! { #intrinsic ( #( #args ),* ) }
+        } else {
+            match op {
+                // Add any special case operations here if needed
+                _ => unimplemented!("missing {op}"),
+            }
+        }
+    }
+}

--- a/fearless_simd_gen/src/arch/wasm.rs
+++ b/fearless_simd_gen/src/arch/wasm.rs
@@ -14,8 +14,8 @@ fn translate_op(op: &str) -> Option<&'static str> {
         "neg" => "neg",
         "floor" => "floor",
         "sqrt" => "sqrt",
-        "add" => "add", // There is also a add_sat
-        "sub" => "sub", // There is also a sub_sat
+        "add" => "add",
+        "sub" => "sub",
         "mul" => "mul",
         "div" => "div",
         "simd_eq" => "eq",

--- a/fearless_simd_gen/src/main.rs
+++ b/fearless_simd_gen/src/main.rs
@@ -10,10 +10,10 @@ mod arch;
 mod generic;
 mod mk_fallback;
 mod mk_neon;
-mod mk_wasm;
 mod mk_ops;
 mod mk_simd_trait;
 mod mk_simd_types;
+mod mk_wasm;
 mod ops;
 mod types;
 

--- a/fearless_simd_gen/src/main.rs
+++ b/fearless_simd_gen/src/main.rs
@@ -10,6 +10,7 @@ mod arch;
 mod generic;
 mod mk_fallback;
 mod mk_neon;
+mod mk_wasm;
 mod mk_ops;
 mod mk_simd_trait;
 mod mk_simd_types;
@@ -22,6 +23,7 @@ enum Module {
     SimdTrait,
     Ops,
     Neon,
+    Wasm,
     Fallback,
 }
 
@@ -38,6 +40,7 @@ impl Module {
             Module::SimdTrait => mk_simd_trait::mk_simd_trait(),
             Module::Ops => mk_ops::mk_ops(),
             Module::Neon => mk_neon::mk_neon_impl(mk_neon::Level::Neon),
+            Module::Wasm => mk_wasm::mk_wasm128_impl(mk_wasm::Level::WasmSimd128),
             Module::Fallback => mk_fallback::mk_fallback_impl(),
         }
     }
@@ -56,6 +59,7 @@ impl Module {
             Module::Ops => "ops",
             Module::Neon => "neon",
             Module::Fallback => "fallback",
+            Module::Wasm => "wasm",
         }
     }
 }

--- a/fearless_simd_gen/src/mk_fallback.rs
+++ b/fearless_simd_gen/src/mk_fallback.rs
@@ -173,11 +173,11 @@ fn mk_simd_impl() -> TokenStream {
                     let mask_type = VecType::new(ScalarType::Mask, vec_ty.scalar_bits, vec_ty.len);
                     let items = make_list(
                         (0..vec_ty.len)
-                            .map(|idx| {
+                            .map(|idx: usize| {
                                 let args = [quote! { &a[#idx] }, quote! { &b[#idx] }];
                                 let expr = Fallback.expr(method, vec_ty, &args);
                                 let mask_ty = mask_type.scalar.rust(scalar_bits);
-                                quote! { #expr as #mask_ty }
+                                quote! { -(#expr as #mask_ty) }
                             })
                             .collect::<Vec<_>>(),
                     );

--- a/fearless_simd_gen/src/mk_fallback.rs
+++ b/fearless_simd_gen/src/mk_fallback.rs
@@ -32,13 +32,13 @@ pub fn mk_fallback_impl() -> TokenStream {
         use crate::{seal::Seal, Level, Simd, SimdInto};
 
         #imports
-        
+
         #[cfg(all(feature = "libm", not(feature = "std")))]
         trait FloatExt {
             fn floor(self) -> f32;
             fn sqrt(self) -> f32;
         }
-        
+
         #[cfg(all(feature = "libm", not(feature = "std")))]
         impl FloatExt for f32 {
             #[inline(always)]
@@ -50,7 +50,7 @@ pub fn mk_fallback_impl() -> TokenStream {
                 libm::sqrtf(self)
             }
         }
-        
+
         /// The SIMD token for the "fallback" level.
         #[derive(Clone, Copy, Debug)]
         pub struct Fallback {

--- a/fearless_simd_gen/src/mk_wasm.rs
+++ b/fearless_simd_gen/src/mk_wasm.rs
@@ -1,0 +1,310 @@
+// Copyright 2025 the Fearless_SIMD Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use proc_macro2::{Span, TokenStream};
+use quote::quote;
+use syn::Ident;
+
+use crate::{
+    arch::{Arch, wasm::Wasm},
+    generic::{generic_combine, generic_op, generic_split},
+    ops::{OpSig, TyFlavor, ops_for_type},
+    types::{SIMD_TYPES, ScalarType, VecType, type_imports},
+};
+
+#[derive(Clone, Copy)]
+pub enum Level {
+    WasmSimd128,
+}
+
+impl Level {
+    fn name(self) -> &'static str {
+        match self {
+            Level::WasmSimd128 => "WasmSimd128",
+        }
+    }
+
+    fn token(self) -> TokenStream {
+        let ident = Ident::new(self.name(), Span::call_site());
+        quote! { #ident }
+    }
+}
+
+fn mk_simd_impl(level: Level) -> TokenStream {
+    let level_tok = level.token();
+    let mut methods = vec![];
+
+    for vec_ty in SIMD_TYPES {
+        let scalar_bits = vec_ty.scalar_bits;
+        let ty_name = vec_ty.rust_name();
+        let ty = vec_ty.rust();
+
+        for (method, sig) in ops_for_type(vec_ty, true) {
+            if vec_ty.n_bits() > 128 && method != "split" {
+                methods.push(generic_op(method, sig, vec_ty));
+                continue;
+            }
+            let method_name = format!("{method}_{ty_name}");
+            let method_ident = Ident::new(&method_name, Span::call_site());
+            let ret_ty = sig.ret_ty(vec_ty, TyFlavor::SimdTrait);
+            let m = match sig {
+                OpSig::Splat => {
+                    let scalar = vec_ty.scalar.rust(scalar_bits);
+                    let expr = Wasm.expr(method, vec_ty, &[quote! { val }]);
+                    quote! {
+                        #[inline(always)]
+                        fn #method_ident(self, val: #scalar) -> #ty<Self> {
+                            #expr.simd_into(self)
+                        }
+                    }
+                }
+                OpSig::Unary if method == "not" => {
+                    let args = [quote! { a.into() }];
+                    let expr = Wasm.expr(method, vec_ty, &args);
+                    quote! {
+                        #[inline(always)]
+                        fn #method_ident(self, a: #ty<Self>) -> #ret_ty {
+                            /// TODO: If v128 is used, we need to reinterpret it.
+                            todo!()
+                        }
+                    }
+                }
+                OpSig::Unary => {
+                    let args = [quote! { a.into() }];
+                    let expr = Wasm.expr(method, vec_ty, &args);
+                    quote! {
+                        #[inline(always)]
+                        fn #method_ident(self, a: #ty<Self>) -> #ret_ty {
+                            #expr.simd_into(self)
+                        }
+                    }
+                }
+                OpSig::Binary if method == "copysign" => {
+                    // let args = [quote! { a.into() }, quote! { b.into() }];
+                    quote! {
+                        #[inline(always)]
+                        fn #method_ident(self, a: #ty<Self>, b: #ty<Self>) -> #ret_ty {
+                            /// TODO: copysign
+                            todo!()
+                        }
+                    }
+                }
+                OpSig::Binary if method == "xor" || method == "or" || method == "and" => {
+                    let args = [quote! { a.into() }, quote! { b.into() }];
+                    let expr = Wasm.expr(method, vec_ty, &args);
+                    quote! {
+                        #[inline(always)]
+                        fn #method_ident(self, a: #ty<Self>, b: #ty<Self>) -> #ret_ty {
+                            /// TODO: If v128 is used we need to reinterpret it accurately...
+                            todo!()
+                        }
+                    }
+                }
+                OpSig::Binary => {
+                    let args = [quote! { a.into() }, quote! { b.into() }];
+                    if method == "mul"
+                        && (vec_ty
+                            == (&VecType {
+                                scalar: ScalarType::Unsigned,
+                                scalar_bits: 8,
+                                len: 16,
+                            })
+                            || vec_ty
+                                == (&VecType {
+                                    scalar: ScalarType::Int,
+                                    scalar_bits: 8,
+                                    len: 16,
+                                }))
+                    {
+                        quote! {
+                            #[inline(always)]
+                            fn #method_ident(self, a: #ty<Self>, b: #ty<Self>) -> #ret_ty {
+                                // TODO: WASM doesn't have `i8x16_mul` or `u8x16_mul`.
+                                todo!()
+                            }
+                        }
+                    } else {
+                        let expr = Wasm.expr(method, vec_ty, &args);
+                        quote! {
+                            #[inline(always)]
+                            fn #method_ident(self, a: #ty<Self>, b: #ty<Self>) -> #ret_ty {
+                                #expr.simd_into(self)
+                            }
+                        }
+                    }
+                }
+                OpSig::Ternary => {
+                    let args = [
+                        quote! { a.into() },
+                        quote! { b.into() },
+                        quote! { c.into() },
+                    ];
+
+                    if method == "madd" {
+                        assert_eq!(
+                            vec_ty,
+                            &VecType {
+                                scalar: ScalarType::Float,
+                                scalar_bits: 32,
+                                len: 4,
+                            }
+                        );
+                        // TODO: `relaxed-simd` has madd.
+                        quote! {
+                            #[inline(always)]
+                            fn #method_ident(self, a: #ty<Self>, b: #ty<Self>, c: #ty<Self>) -> #ret_ty {
+                                self.add_f32x4(a, self.mul_f32x4(b, c))
+                            }
+                        }
+                    } else {
+                        let expr = Wasm.expr(method, vec_ty, &args);
+                        quote! {
+                            #[inline(always)]
+                            fn #method_ident(self, a: #ty<Self>, b: #ty<Self>, c: #ty<Self>) -> #ret_ty {
+                                // TODO: OpSig::Ternary
+                                todo!()
+                            }
+                        }
+                    }
+                }
+                OpSig::Compare => {
+                    let args = [quote! { a.into() }, quote! { b.into() }];
+                    let expr = Wasm.expr(method, vec_ty, &args);
+                    quote! {
+                        #[inline(always)]
+                        fn #method_ident(self, a: #ty<Self>, b: #ty<Self>) -> #ret_ty {
+                            #expr.simd_into(self)
+                        }
+                    }
+                }
+                OpSig::Select => {
+                    let mask_ty = vec_ty.mask_ty().rust();
+                    quote! {
+                        #[inline(always)]
+                        fn #method_ident(self, a: #mask_ty<Self>, b: #ty<Self>, c: #ty<Self>) -> #ret_ty {
+                            todo!()
+                        }
+                    }
+                }
+                OpSig::Combine => generic_combine(vec_ty),
+                OpSig::Split => generic_split(vec_ty),
+                OpSig::Zip => {
+                    quote! {
+                        #[inline(always)]
+                        fn #method_ident(self, a: #ty<Self>, b: #ty<Self>) -> #ret_ty {
+                            todo!()
+                        }
+                    }
+                }
+                OpSig::Cvt(scalar, scalar_bits) => {
+                    // let to_ty = &VecType::new(scalar, scalar_bits, vec_ty.len);
+                    quote! {
+                        #[inline(always)]
+                        fn #method_ident(self, a: #ty<Self>) -> #ret_ty {
+                            todo!()
+                        }
+                    }
+                }
+            };
+
+            methods.push(m);
+        }
+    }
+
+    quote! {
+        impl Simd for #level_tok {
+            type f32s = f32x4<Self>;
+            type u8s = u8x16<Self>;
+            type i8s = i8x16<Self>;
+            type u16s = u16x8<Self>;
+            type i16s = i16x8<Self>;
+            type u32s = u32x4<Self>;
+            type i32s = i32x4<Self>;
+            type mask8s = mask8x16<Self>;
+            type mask16s = mask16x8<Self>;
+            type mask32s = mask32x4<Self>;
+
+            #[inline(always)]
+            fn level(self) -> Level {
+                Level::#level_tok(self)
+            }
+
+            #[inline]
+            fn vectorize<F: FnOnce() -> R, R>(self, f: F) -> R {
+                #[target_feature(enable = "simd128")]
+                #[inline]
+                // unsafe not needed here with tf11, but can be justified
+                unsafe fn vectorize_simd128<F: FnOnce() -> R, R>(f: F) -> R {
+                    f()
+                }
+                unsafe { vectorize_simd128(f) }
+            }
+
+            #( #methods )*
+        }
+    }
+}
+
+pub fn mk_wasm128_impl(level: Level) -> TokenStream {
+    let imports = type_imports();
+    let simd_impl = mk_simd_impl(level);
+    let ty_impl = mk_type_impl();
+    let level_tok = level.token();
+
+    quote! {
+        use core::arch::wasm32::*;
+
+        use crate::{seal::Seal, Level, Simd, SimdFrom, SimdInto};
+
+        #imports
+
+        /// The SIMD token for the "wasm128" level.
+        #[derive(Clone, Copy, Debug)]
+        pub struct #level_tok {
+            _private: (),
+        }
+
+        impl #level_tok {
+            #[inline]
+            pub fn new_unchecked() -> Self {
+                Self { _private: () }
+            }
+        }
+
+        impl Seal for #level_tok {}
+
+        #simd_impl
+
+        #ty_impl
+    }
+}
+
+fn mk_type_impl() -> TokenStream {
+    let mut result = vec![];
+    for ty in SIMD_TYPES {
+        if ty.n_bits() != 128 {
+            continue;
+        }
+        let simd = ty.rust();
+        result.push(quote! {
+            impl<S: Simd> SimdFrom<v128, S> for #simd<S> {
+                #[inline(always)]
+                fn simd_from(arch: v128, simd: S) -> Self {
+                    Self {
+                        val: unsafe { core::mem::transmute(arch) },
+                        simd
+                    }
+                }
+            }
+            impl<S: Simd> From<#simd<S>> for v128 {
+                #[inline(always)]
+                fn from(value: #simd<S>) -> Self {
+                    unsafe { core::mem::transmute(value.val) }
+                }
+            }
+        })
+    }
+    quote! {
+        #( #result )*
+    }
+}

--- a/fearless_simd_tests/Cargo.toml
+++ b/fearless_simd_tests/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "fearless_simd_tests"
+license.workspace = true
+edition.workspace = true
+authors = ["Raph Levien <raph.levien@gmail.com>"]
+keywords = ["simd"]
+categories = ["hardware-support"]
+description = "Safer and easier SIMD"
+readme = "README.md"
+rust-version = "1.85"
+publish = false
+
+[[test]]
+name = "tests"
+path = "tests/mod.rs"
+
+[dependencies]
+fearless_simd = { workspace = true }
+
+[target.'cfg(target_arch = "wasm32")'.dev-dependencies]
+wasm-bindgen-test = "0.3.50"
+wasm-bindgen = "0.2.100"

--- a/fearless_simd_tests/README.md
+++ b/fearless_simd_tests/README.md
@@ -1,0 +1,19 @@
+<div align="center">
+
+# Fearless SIMD Tests
+
+</div>
+
+This is a development-only crate for testing `fearless_simd`.
+
+
+### Testing WebAssembly +simd128
+
+Run browser tests with:
+
+```sh
+wasm-pack test --headless --chrome
+```
+
+Currently these tests only enforce that WASM SIMD and the fallback scalar implementations match when
+run in the browser.

--- a/fearless_simd_tests/tests/mod.rs
+++ b/fearless_simd_tests/tests/mod.rs
@@ -1,0 +1,8 @@
+// Copyright 2025 the Fearless_SIMD Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+#[cfg(target_arch = "wasm32")]
+wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
+
+#[cfg(target_arch = "wasm32")]
+mod wasm;

--- a/fearless_simd_tests/tests/wasm.rs
+++ b/fearless_simd_tests/tests/wasm.rs
@@ -1,0 +1,228 @@
+// Copyright 2025 the Fearless_SIMD Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+
+#[cfg(target_arch = "wasm32")]
+use fearless_simd::*;
+#[cfg(target_arch = "wasm32")]
+use wasm_bindgen_test::*;
+
+/// `test_wasm_simd_parity` enforces that the fallback level and +simd128 levels output the same
+/// results.
+macro_rules! test_wasm_simd_parity {
+    (
+        fn $test_name:ident() {
+            |$s:ident| -> $ret_type:ty $body:block
+        }
+    ) => {
+        #[cfg(target_arch = "wasm32")]
+        #[wasm_bindgen_test]
+        fn $test_name() {
+            fn test_impl<S: Simd>($s: S) -> $ret_type $body
+
+            simd_dispatch!(dispatch(level) -> $ret_type = test_impl);
+
+            let fallback_result = dispatch(Level::Fallback(Fallback::new()));
+            let wasm_result = dispatch(Level::WasmSimd128(wasm32::WasmSimd128::new_unchecked()));
+
+            assert_eq!(fallback_result, wasm_result,
+                concat!(stringify!($test_name), ": Expected fallback and WASM SIMD results to match."));
+        }
+    };
+}
+
+
+test_wasm_simd_parity! {
+    fn test_add_f32x4() {
+        |s| -> [f32; 4] {
+            let a = f32x4::from_slice(s, &[1.0, 2.0, 3.0, 4.0]);
+            let b = f32x4::from_slice(s, &[5.0, 4.0, 3.0, 2.0]);
+            (a + b).into()
+        }
+    }
+}
+
+test_wasm_simd_parity! {
+    fn test_sub_f32x4() {
+        |s| -> [f32; 4] {
+            let a = f32x4::from_slice(s, &[1.0, 2.0, 3.0, 4.0]);
+            let b = f32x4::from_slice(s, &[5.0, 4.0, 3.0, 2.0]);
+            (a - b).into()
+        }
+    }
+}
+
+test_wasm_simd_parity! {
+    fn test_mul_f32x4() {
+        |s| -> [f32; 4] {
+            let a = f32x4::from_slice(s, &[1.0, 2.0, 3.0, 4.0]);
+            let b = f32x4::from_slice(s, &[5.0, 4.0, 3.0, 2.0]);
+            (a - b).into()
+        }
+    }
+}
+
+test_wasm_simd_parity! {
+    fn test_splat_f32x4() {
+        |s| -> [f32; 4] {
+            f32x4::splat(s, 1.0).into()
+        }
+    }
+}
+
+test_wasm_simd_parity! {
+    fn test_abs_f32x4() {
+        |s| -> [f32; 4] {
+            let a = f32x4::from_slice(s, &[-1.0, 0., 1.0, 2.3]);
+            f32x4::abs(a).into()
+        }
+    }
+}
+
+test_wasm_simd_parity! {
+    fn test_neg_f32x4() {
+        |s| -> [f32; 4] {
+            let a = f32x4::from_slice(s, &[-1.0, 0.0, 1.0, 2.3]);
+            f32x4::neg(a).into()
+        }
+    }
+}
+
+test_wasm_simd_parity! {
+    fn test_sqrt_f32x4() {
+        |s| -> [f32; 4] {
+            let a = f32x4::from_slice(s, &[4.0, 0.0, 1.0, 2.0]);
+            f32x4::sqrt(a).into()
+        }
+    }
+}
+
+test_wasm_simd_parity! {
+    fn test_div_f32x4() {
+        |s| -> [f32; 4] {
+            let a = f32x4::from_slice(s, &[4.0, 2.0, 1.0, 0.0]);
+            let b = f32x4::from_slice(s, &[4., 1.0, 3.0, 0.1]);
+            (a / b).into()
+        }
+    }
+}
+
+test_wasm_simd_parity! {
+    fn test_simd_eq_f32x4() {
+        |s| -> [i32; 4] {
+            let a = f32x4::from_slice(s, &[4.0, 2.0, 1.0, 0.0]);
+            let b = f32x4::from_slice(s, &[4.0, 3.1, 1.0, 0.0]);
+            a.simd_eq(b).into()
+        }
+    }
+}
+
+test_wasm_simd_parity! {
+    fn test_simd_lt_f32x4() {
+        |s| -> [i32; 4] {
+            let a = f32x4::from_slice(s, &[4.0, 3.0, 2.0, 1.0]);
+            let b = f32x4::from_slice(s, &[1.0, 2.0, 2.0, 4.0]);
+            a.simd_lt(b).into()
+        }
+    }
+}
+
+test_wasm_simd_parity! {
+    fn test_simd_le_f32x4() {
+        |s| -> [i32; 4] {
+            let a = f32x4::from_slice(s, &[4.0, 3.0, 2.0, 1.0]);
+            let b = f32x4::from_slice(s, &[1.0, 2.0, 2.0, 4.0]);
+            a.simd_le(b).into()
+        }
+    }
+}
+
+test_wasm_simd_parity! {
+    fn test_simd_ge_f32x4() {
+        |s| -> [i32; 4] {
+            let a = f32x4::from_slice(s, &[4.0, 3.0, 2.0, 1.0]);
+            let b = f32x4::from_slice(s, &[1.0, 2.0, 2.0, 4.0]);
+            a.simd_ge(b).into()
+        }
+    }
+}
+
+test_wasm_simd_parity! {
+    fn test_simd_gt_f32x4() {
+        |s| -> [i32; 4] {
+            let a = f32x4::from_slice(s, &[4.0, 3.0, 2.0, 1.0]);
+            let b = f32x4::from_slice(s, &[1.0, 2.0, 2.0, 4.0]);
+            a.simd_gt(b).into()
+        }
+    }
+}
+
+test_wasm_simd_parity! {
+    fn test_madd_f32x4() {
+        |s| -> [f32; 4] {
+            let a = f32x4::from_slice(s, &[2.0, -3.0, 0.0, 0.5]);
+            let b = f32x4::from_slice(s, &[5.0, 4.0, 100.0, 8.0]);
+            let c = f32x4::from_slice(s, &[1.0, -2.0, 7.0, 3.0]);
+            a.madd(b, c).into()
+        }
+    }
+}
+
+test_wasm_simd_parity! {
+    fn test_max_f32x4() {
+        |s| -> [f32; 4] {
+            let a = f32x4::from_slice(s, &[2.0, -3.0, 0.0, 0.5]);
+            let b = f32x4::from_slice(s, &[1.0, -2.0, 7.0, 3.0]);
+            a.max(b).into()
+        }
+    }
+}
+
+test_wasm_simd_parity! {
+    fn test_min_f32x4() {
+        |s| -> [f32; 4] {
+            let a = f32x4::from_slice(s, &[2.0, -3.0, 0.0, 0.5]);
+            let b = f32x4::from_slice(s, &[1.0, -2.0, 7.0, 3.0]);
+            a.min(b).into()
+        }
+    }
+}
+
+test_wasm_simd_parity! {
+    fn test_max_precise_f32x4() {
+        |s| -> [f32; 4] {
+            let a = f32x4::from_slice(s, &[2.0, -3.0, 0.0, 0.5]);
+            let b = f32x4::from_slice(s, &[1.0, -2.0, 7.0, 3.0]);
+            a.max_precise(b).into()
+        }
+    }
+}
+
+test_wasm_simd_parity! {
+    fn test_min_precise_f32x4() {
+        |s| -> [f32; 4] {
+            let a = f32x4::from_slice(s, &[2.0, -3.0, 0.0, 0.5]);
+            let b = f32x4::from_slice(s, &[1.0, -2.0, 7.0, 3.0]);
+            a.min_precise(b).into()
+        }
+    }
+}
+
+test_wasm_simd_parity! {
+    fn test_floor_f32x4() {
+        |s| -> [f32; 4] {
+            let a = f32x4::from_slice(s, &[2.0, -3.2, 0.0, 0.5]);
+            a.floor().into()
+        }
+    }
+}
+
+test_wasm_simd_parity! {
+    fn test_combine_f32x4() {
+        |s| -> [f32; 8] {
+            let a = f32x4::from_slice(s, &[1.0, 2.0, 3.0, 4.0]);
+            let b = f32x4::from_slice(s, &[5.0, 6.0, 7.0, 8.0]);
+            a.combine(b).into()
+        }
+    }
+}

--- a/fearless_simd_tests/tests/wasm.rs
+++ b/fearless_simd_tests/tests/wasm.rs
@@ -1,7 +1,6 @@
 // Copyright 2025 the Fearless_SIMD Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-
 #[cfg(target_arch = "wasm32")]
 use fearless_simd::*;
 #[cfg(target_arch = "wasm32")]
@@ -30,7 +29,6 @@ macro_rules! test_wasm_simd_parity {
         }
     };
 }
-
 
 test_wasm_simd_parity! {
     fn test_add_f32x4() {

--- a/fearless_simd_tests/tests/wasm.rs
+++ b/fearless_simd_tests/tests/wasm.rs
@@ -31,7 +31,7 @@ macro_rules! test_wasm_simd_parity {
 }
 
 test_wasm_simd_parity! {
-    fn test_add_f32x4() {
+    fn add_f32x4() {
         |s| -> [f32; 4] {
             let a = f32x4::from_slice(s, &[1.0, 2.0, 3.0, 4.0]);
             let b = f32x4::from_slice(s, &[5.0, 4.0, 3.0, 2.0]);
@@ -41,7 +41,7 @@ test_wasm_simd_parity! {
 }
 
 test_wasm_simd_parity! {
-    fn test_sub_f32x4() {
+    fn sub_f32x4() {
         |s| -> [f32; 4] {
             let a = f32x4::from_slice(s, &[1.0, 2.0, 3.0, 4.0]);
             let b = f32x4::from_slice(s, &[5.0, 4.0, 3.0, 2.0]);
@@ -51,7 +51,7 @@ test_wasm_simd_parity! {
 }
 
 test_wasm_simd_parity! {
-    fn test_mul_f32x4() {
+    fn mul_f32x4() {
         |s| -> [f32; 4] {
             let a = f32x4::from_slice(s, &[1.0, 2.0, 3.0, 4.0]);
             let b = f32x4::from_slice(s, &[5.0, 4.0, 3.0, 2.0]);
@@ -61,7 +61,7 @@ test_wasm_simd_parity! {
 }
 
 test_wasm_simd_parity! {
-    fn test_splat_f32x4() {
+    fn splat_f32x4() {
         |s| -> [f32; 4] {
             f32x4::splat(s, 1.0).into()
         }
@@ -69,7 +69,7 @@ test_wasm_simd_parity! {
 }
 
 test_wasm_simd_parity! {
-    fn test_abs_f32x4() {
+    fn abs_f32x4() {
         |s| -> [f32; 4] {
             let a = f32x4::from_slice(s, &[-1.0, 0., 1.0, 2.3]);
             f32x4::abs(a).into()
@@ -78,7 +78,7 @@ test_wasm_simd_parity! {
 }
 
 test_wasm_simd_parity! {
-    fn test_neg_f32x4() {
+    fn neg_f32x4() {
         |s| -> [f32; 4] {
             let a = f32x4::from_slice(s, &[-1.0, 0.0, 1.0, 2.3]);
             f32x4::neg(a).into()
@@ -87,7 +87,7 @@ test_wasm_simd_parity! {
 }
 
 test_wasm_simd_parity! {
-    fn test_sqrt_f32x4() {
+    fn sqrt_f32x4() {
         |s| -> [f32; 4] {
             let a = f32x4::from_slice(s, &[4.0, 0.0, 1.0, 2.0]);
             f32x4::sqrt(a).into()
@@ -96,7 +96,7 @@ test_wasm_simd_parity! {
 }
 
 test_wasm_simd_parity! {
-    fn test_div_f32x4() {
+    fn div_f32x4() {
         |s| -> [f32; 4] {
             let a = f32x4::from_slice(s, &[4.0, 2.0, 1.0, 0.0]);
             let b = f32x4::from_slice(s, &[4., 1.0, 3.0, 0.1]);
@@ -106,7 +106,7 @@ test_wasm_simd_parity! {
 }
 
 test_wasm_simd_parity! {
-    fn test_simd_eq_f32x4() {
+    fn simd_eq_f32x4() {
         |s| -> [i32; 4] {
             let a = f32x4::from_slice(s, &[4.0, 2.0, 1.0, 0.0]);
             let b = f32x4::from_slice(s, &[4.0, 3.1, 1.0, 0.0]);
@@ -116,7 +116,7 @@ test_wasm_simd_parity! {
 }
 
 test_wasm_simd_parity! {
-    fn test_simd_lt_f32x4() {
+    fn simd_lt_f32x4() {
         |s| -> [i32; 4] {
             let a = f32x4::from_slice(s, &[4.0, 3.0, 2.0, 1.0]);
             let b = f32x4::from_slice(s, &[1.0, 2.0, 2.0, 4.0]);
@@ -126,7 +126,7 @@ test_wasm_simd_parity! {
 }
 
 test_wasm_simd_parity! {
-    fn test_simd_le_f32x4() {
+    fn simd_le_f32x4() {
         |s| -> [i32; 4] {
             let a = f32x4::from_slice(s, &[4.0, 3.0, 2.0, 1.0]);
             let b = f32x4::from_slice(s, &[1.0, 2.0, 2.0, 4.0]);
@@ -136,7 +136,7 @@ test_wasm_simd_parity! {
 }
 
 test_wasm_simd_parity! {
-    fn test_simd_ge_f32x4() {
+    fn simd_ge_f32x4() {
         |s| -> [i32; 4] {
             let a = f32x4::from_slice(s, &[4.0, 3.0, 2.0, 1.0]);
             let b = f32x4::from_slice(s, &[1.0, 2.0, 2.0, 4.0]);
@@ -146,7 +146,7 @@ test_wasm_simd_parity! {
 }
 
 test_wasm_simd_parity! {
-    fn test_simd_gt_f32x4() {
+    fn simd_gt_f32x4() {
         |s| -> [i32; 4] {
             let a = f32x4::from_slice(s, &[4.0, 3.0, 2.0, 1.0]);
             let b = f32x4::from_slice(s, &[1.0, 2.0, 2.0, 4.0]);
@@ -156,7 +156,7 @@ test_wasm_simd_parity! {
 }
 
 test_wasm_simd_parity! {
-    fn test_madd_f32x4() {
+    fn madd_f32x4() {
         |s| -> [f32; 4] {
             let a = f32x4::from_slice(s, &[2.0, -3.0, 0.0, 0.5]);
             let b = f32x4::from_slice(s, &[5.0, 4.0, 100.0, 8.0]);
@@ -167,7 +167,7 @@ test_wasm_simd_parity! {
 }
 
 test_wasm_simd_parity! {
-    fn test_max_f32x4() {
+    fn max_f32x4() {
         |s| -> [f32; 4] {
             let a = f32x4::from_slice(s, &[2.0, -3.0, 0.0, 0.5]);
             let b = f32x4::from_slice(s, &[1.0, -2.0, 7.0, 3.0]);
@@ -177,7 +177,7 @@ test_wasm_simd_parity! {
 }
 
 test_wasm_simd_parity! {
-    fn test_min_f32x4() {
+    fn min_f32x4() {
         |s| -> [f32; 4] {
             let a = f32x4::from_slice(s, &[2.0, -3.0, 0.0, 0.5]);
             let b = f32x4::from_slice(s, &[1.0, -2.0, 7.0, 3.0]);
@@ -187,7 +187,7 @@ test_wasm_simd_parity! {
 }
 
 test_wasm_simd_parity! {
-    fn test_max_precise_f32x4() {
+    fn max_precise_f32x4() {
         |s| -> [f32; 4] {
             let a = f32x4::from_slice(s, &[2.0, -3.0, 0.0, 0.5]);
             let b = f32x4::from_slice(s, &[1.0, -2.0, 7.0, 3.0]);
@@ -197,7 +197,7 @@ test_wasm_simd_parity! {
 }
 
 test_wasm_simd_parity! {
-    fn test_min_precise_f32x4() {
+    fn min_precise_f32x4() {
         |s| -> [f32; 4] {
             let a = f32x4::from_slice(s, &[2.0, -3.0, 0.0, 0.5]);
             let b = f32x4::from_slice(s, &[1.0, -2.0, 7.0, 3.0]);
@@ -207,7 +207,7 @@ test_wasm_simd_parity! {
 }
 
 test_wasm_simd_parity! {
-    fn test_floor_f32x4() {
+    fn floor_f32x4() {
         |s| -> [f32; 4] {
             let a = f32x4::from_slice(s, &[2.0, -3.2, 0.0, 0.5]);
             a.floor().into()
@@ -216,7 +216,7 @@ test_wasm_simd_parity! {
 }
 
 test_wasm_simd_parity! {
-    fn test_combine_f32x4() {
+    fn combine_f32x4() {
         |s| -> [f32; 8] {
             let a = f32x4::from_slice(s, &[1.0, 2.0, 3.0, 4.0]);
             let b = f32x4::from_slice(s, &[5.0, 6.0, 7.0, 8.0]);


### PR DESCRIPTION
> [!NOTE]
> The measurements in this PR were done very rough via a quick Chrome profile. Because the numbers are small, until we run a rigorous benchmark it'll be hard to validate the impact. Especially across browser engines, and with JS engines optimising WASM and fusing operators.

## Overview

This PR adds initial WASM SIMD support to `fearless_simd`, implementing enough operations to enable WASM SIMD in https://github.com/linebender/vello/pull/1053. Rather than implementing all operations in one large PR, this focuses on the essential subset needed for Vello and breaks up an otherwise huge change. There's also some tricky operations to implement using the small amount of WASM instructions 😅 .

## Performance Impact

Tested with Ghost Tiger rendering in Vello:

### Without fast kurbo (baseline):
- **Without SIMD**: ~42.31ms per frame
- **With SIMD**: ~39.91ms per frame  
- **Improvement**: ~5% faster

### With fast kurbo (https://github.com/linebender/kurbo/pull/427):
- **Without SIMD**: ~6ms per frame
- **With SIMD**: ~4ms per frame
- **Improvement**: ~30% faster (Take this with a huge grain of salt)

*Test methodology: I linked `vello` locally to `fearless_simd` via `path` reference, and modified `vello_hybrid` to use the WASM SIMD level.*

## Changes

- **New architecture**: Added WASM SIMD128 support
- **Operations implemented**: Core subset including:
  - Binary ops: `add`, `sub`, `mul`, `min`, `max`
  - Comparison ops: `simd_eq`, `simd_ne`, `simd_lt`, etc.
  - Math ops: `sqrt`, `madd`
- **Testing**: Added parity tests ensuring Fallback and WASM SIMD produce identical results
- **Bug fix**: Fixed incorrect mask generation in Fallback comparison operations (was returning `0/1` instead of `0/-1`)

## Test Plan

Added `test_wasm_simd_parity!` macro that verifies operations produce identical results across Fallback and WASM SIMD implementations.

I only tested a small subset. Maybe in the future we code-gen the tests as well?

## Next Steps

Future PRs will add more operations to achieve full WASM SIMD coverage.