### PR TITLE
Fix dispatch macro

### DIFF
--- a/fearless_simd/src/macros.rs
+++ b/fearless_simd/src/macros.rs
@@ -3,6 +3,7 @@
 
 //! Macros publicly exported
 
+#[cfg(feature = "std")]
 #[macro_export]
 macro_rules! simd_dispatch {
     (
@@ -12,7 +13,7 @@ macro_rules! simd_dispatch {
     ) => {
         $( #[$meta] )* $vis
         fn $func(level: $crate::Level $(, $arg: $ty )*) $( -> $ret )? {
-            #[cfg(all(feature = "std", target_arch = "aarch64"))]
+            #[cfg(target_arch = "aarch64")]
             #[target_feature(enable = "neon")]
             #[inline]
             unsafe fn inner_neon(neon: $crate::aarch64::Neon $( , $arg: $ty )* ) $( -> $ret )? {
@@ -26,8 +27,33 @@ macro_rules! simd_dispatch {
             }
             match level {
                 Level::Fallback(fb) => $inner(fb $( , $arg )* ),
-                #[cfg(all(feature = "std", target_arch = "aarch64"))]
+                #[cfg(target_arch = "aarch64")]
                 Level::Neon(neon) => unsafe { inner_neon (neon $( , $arg )* ) }
+                #[cfg(target_arch = "wasm32")]
+                Level::WasmSimd128(wasm) => unsafe { inner_wasm_simd128 (wasm $( , $arg )* ) }
+            }
+        }
+    };
+}
+
+#[cfg(not(feature = "std"))]
+#[macro_export]
+macro_rules! simd_dispatch {
+    (
+        $( #[$meta:meta] )* $vis:vis
+        $func:ident ( level $( , $arg:ident : $ty:ty $(,)? )* ) $( -> $ret:ty )?
+        = $inner:ident
+    ) => {
+        $( #[$meta] )* $vis
+        fn $func(level: $crate::Level $(, $arg: $ty )*) $( -> $ret )? {
+            #[cfg(target_arch = "wasm32")]
+            #[target_feature(enable = "simd128")]
+            #[inline]
+            unsafe fn inner_wasm_simd128(simd128: $crate::wasm32::WasmSimd128 $( , $arg: $ty )* ) $( -> $ret )? {
+                $inner( simd128 $( , $arg )* )
+            }
+            match level {
+                Level::Fallback(fb) => $inner(fb $( , $arg )* ),
                 #[cfg(target_arch = "wasm32")]
                 Level::WasmSimd128(wasm) => unsafe { inner_wasm_simd128 (wasm $( , $arg )* ) }
             }


### PR DESCRIPTION
Having `feature = "std"` will check for the feature in the crate the macro is included, not in `fearless_simd`. This happened to work fine for vello because we have an explicit `std` feature there, but it won't work for crates that don't.