### PR TITLE
[WASM] fix unconditional SIMD inclusion in WASM binary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
           tool: wasm-pack
 
       - name: Run fearless_simd_tests on Chrome
-        run: wasm-pack test --headless --chrome
+        run: RUSTFLAGS=-Ctarget-feature=+simd128 wasm-pack test --headless --chrome
         working-directory: fearless_simd_tests
   
   build-no-std:

--- a/fearless_simd/src/generated.rs
+++ b/fearless_simd/src/generated.rs
@@ -11,7 +11,7 @@ mod neon;
 mod ops;
 mod simd_trait;
 mod simd_types;
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
 mod wasm;
 
 pub use fallback::*;
@@ -19,5 +19,5 @@ pub use fallback::*;
 pub use neon::*;
 pub use simd_trait::*;
 pub use simd_types::*;
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
 pub use wasm::*;

--- a/fearless_simd/src/generated/wasm.rs
+++ b/fearless_simd/src/generated/wasm.rs
@@ -36,7 +36,6 @@ impl Simd for WasmSimd128 {
     }
     #[inline]
     fn vectorize<F: FnOnce() -> R, R>(self, f: F) -> R {
-        #[target_feature(enable = "simd128")]
         #[inline]
         unsafe fn vectorize_simd128<F: FnOnce() -> R, R>(f: F) -> R {
             f()

--- a/fearless_simd/src/lib.rs
+++ b/fearless_simd/src/lib.rs
@@ -34,7 +34,7 @@ pub mod aarch64 {
     pub use crate::generated::Neon;
 }
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
 pub mod wasm32 {
     pub use crate::generated::WasmSimd128;
 }
@@ -45,7 +45,7 @@ pub enum Level {
     Fallback(Fallback),
     #[cfg(all(feature = "std", target_arch = "aarch64"))]
     Neon(Neon),
-    #[cfg(target_arch = "wasm32")]
+    #[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
     WasmSimd128(WasmSimd128),
 }
 
@@ -70,7 +70,7 @@ impl Level {
         }
     }
 
-    #[cfg(target_arch = "wasm32")]
+    #[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
     #[inline]
     pub fn as_wasm_simd128(self) -> Option<WasmSimd128> {
         match self {
@@ -94,8 +94,7 @@ impl Level {
             f.with_simd(neon)
         }
 
-        #[cfg(target_arch = "wasm32")]
-        #[target_feature(enable = "simd128")]
+        #[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
         #[inline]
         fn dispatch_simd128<W: WithSimd>(f: W, simd128: WasmSimd128) -> W::Output {
             f.with_simd(simd128)
@@ -109,7 +108,7 @@ impl Level {
         match self {
             #[cfg(all(feature = "std", target_arch = "aarch64"))]
             Level::Neon(neon) => unsafe { dispatch_neon(f, neon) },
-            #[cfg(target_arch = "wasm32")]
+            #[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
             Level::WasmSimd128(simd128) => dispatch_simd128(f, simd128),
             Level::Fallback(fallback) => dispatch_fallback(f, fallback),
         }

--- a/fearless_simd_gen/src/mk_wasm.rs
+++ b/fearless_simd_gen/src/mk_wasm.rs
@@ -257,7 +257,6 @@ fn mk_simd_impl(level: Level) -> TokenStream {
 
             #[inline]
             fn vectorize<F: FnOnce() -> R, R>(self, f: F) -> R {
-                #[target_feature(enable = "simd128")]
                 #[inline]
                 // unsafe not needed here with tf11, but can be justified
                 unsafe fn vectorize_simd128<F: FnOnce() -> R, R>(f: F) -> R {

--- a/fearless_simd_tests/tests/mod.rs
+++ b/fearless_simd_tests/tests/mod.rs
@@ -4,5 +4,5 @@
 #[cfg(target_arch = "wasm32")]
 wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
 mod wasm;


### PR DESCRIPTION
### Context

I made a mistake using `#[target_feature(enable = "simd128")]` because it means the enclosed code is compiled using the simd128 feature flag. This can result in binaries containing SIMD. Even if the SIMD is never executed, older browsers may fail to validate the WASM binary if it includes SIMD instructions.

Thus, this PR removes all usages of target_feature for WASM, instead opting into optional compilation.

### Test plan

This really needs an automated test, but I haven't found a good way to test this yet.

I manually tested by running the following command:

```
cargo build --example srgb --target=wasm32-unknown-unknown && wasm2wat ./target/wasm32-unknown-unknown/debug/examples/srgb.wasm | grep -q v128 && echo "SIMD FOUND" || echo "NO SIMD"
```

Now returns `NO SIMD` , when previously it returned `SIMD FOUND`.

```
RUSTFLAGS=-Ctarget-feature=+simd128 cargo build --example srgb --target=wasm32-unknown-unknown && wasm2wat ./target/wasm32-unknown-unknown/debug/examples/srgb.wasm | grep -q v128 && echo "SIMD FOUND" || echo "NO SIMD"
```

Returns `SIMD FOUND` because the `+simd128` feature was requested.