### PR TITLE
Fix WASM `pmax` and `pmin` such that vello_cpu tests pass

### DIFF
--- a/fearless_simd/src/generated/wasm.rs
+++ b/fearless_simd/src/generated/wasm.rs
@@ -113,7 +113,7 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn max_precise_f32x4(self, a: f32x4<Self>, b: f32x4<Self>) -> f32x4<Self> {
-        f32x4_max(a.into(), b.into()).simd_into(self)
+        f32x4_pmax(b.into(), a.into()).simd_into(self)
     }
     #[inline(always)]
     fn min_f32x4(self, a: f32x4<Self>, b: f32x4<Self>) -> f32x4<Self> {
@@ -121,7 +121,7 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn min_precise_f32x4(self, a: f32x4<Self>, b: f32x4<Self>) -> f32x4<Self> {
-        f32x4_min(a.into(), b.into()).simd_into(self)
+        f32x4_pmin(b.into(), a.into()).simd_into(self)
     }
     #[inline(always)]
     fn madd_f32x4(self, a: f32x4<Self>, b: f32x4<Self>, c: f32x4<Self>) -> f32x4<Self> {

--- a/fearless_simd_gen/src/arch/wasm.rs
+++ b/fearless_simd_gen/src/arch/wasm.rs
@@ -27,12 +27,10 @@ fn translate_op(op: &str) -> Option<&'static str> {
         "and" => "and",
         "or" => "or",
         "xor" => "xor",
-        // TODO: With target-feature "relaxed-simd" this could be "relaxed_max".
         "max" => "max",
-        // TODO: With target-feature "relaxed-simd" this could be "relaxed_min".
         "min" => "min",
-        "max_precise" => "max",
-        "min_precise" => "min",
+        "max_precise" => "pmax",
+        "min_precise" => "pmin",
         "splat" => "splat",
         // TODO: Only target-feature "relaxed-simd" has "relaxed_madd".
         _ => return None,

--- a/fearless_simd_tests/README.md
+++ b/fearless_simd_tests/README.md
@@ -12,7 +12,7 @@ This is a development-only crate for testing `fearless_simd`.
 Run browser tests with:
 
 ```sh
-wasm-pack test --headless --chrome
+RUSTFLAGS=-Ctarget-feature=+simd128 wasm-pack test --headless --chrome
 ```
 
 Currently these tests only enforce that WASM SIMD and the fallback scalar implementations match when

--- a/fearless_simd_tests/tests/wasm.rs
+++ b/fearless_simd_tests/tests/wasm.rs
@@ -1,7 +1,7 @@
 // Copyright 2025 the Fearless_SIMD Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-#![cfg(target_arch = "wasm32")]
+#![cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
 
 use fearless_simd::*;
 use wasm_bindgen_test::*;

--- a/fearless_simd_tests/tests/wasm.rs
+++ b/fearless_simd_tests/tests/wasm.rs
@@ -1,9 +1,9 @@
 // Copyright 2025 the Fearless_SIMD Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-#[cfg(target_arch = "wasm32")]
+#![cfg(target_arch = "wasm32")]
+
 use fearless_simd::*;
-#[cfg(target_arch = "wasm32")]
 use wasm_bindgen_test::*;
 
 /// `test_wasm_simd_parity` enforces that the fallback level and +simd128 levels output the same
@@ -14,7 +14,6 @@ macro_rules! test_wasm_simd_parity {
             |$s:ident| -> $ret_type:ty $body:block
         }
     ) => {
-        #[cfg(target_arch = "wasm32")]
         #[wasm_bindgen_test]
         fn $test_name() {
             fn test_impl<S: Simd>($s: S) -> $ret_type $body
@@ -223,6 +222,50 @@ test_wasm_simd_parity! {
             let b = f32x4::from_slice(s, &[1.0, -2.0, 7.0, 3.0]);
             a.min_precise(b).into()
         }
+    }
+}
+
+#[wasm_bindgen_test]
+fn max_precise_f32x4_with_nan() {
+    fn test_impl<S: Simd>(s: S) -> [f32; 4] {
+        let a = f32x4::from_slice(s, &[f32::NAN, -3.0, f32::INFINITY, 0.5]);
+        let b = f32x4::from_slice(s, &[1.0, f32::NAN, 7.0, f32::NEG_INFINITY]);
+        a.max_precise(b).into()
+    }
+
+    simd_dispatch!(test(level) -> [f32; 4] = test_impl);
+    let wasm_result = test(Level::WasmSimd128(wasm32::WasmSimd128::new_unchecked()));
+
+    // Note: f32::NAN != f32::NAN hence we transmute to compare the bit pattern. In this case NaN
+    // bit pattern is preserved.
+    unsafe {
+        assert_eq!(
+            std::mem::transmute::<[f32; 4], [u32; 4]>(wasm_result),
+            std::mem::transmute::<[f32; 4], [u32; 4]>([1., f32::NAN, f32::INFINITY, 0.5]),
+            "Wasm did not match expected result."
+        );
+    }
+}
+
+#[wasm_bindgen_test]
+fn min_precise_f32x4_with_nan() {
+    fn test_impl<S: Simd>(s: S) -> [f32; 4] {
+        let a = f32x4::from_slice(s, &[f32::NAN, -3.0, f32::INFINITY, 0.5]);
+        let b = f32x4::from_slice(s, &[1.0, f32::NAN, 7.0, f32::NEG_INFINITY]);
+        a.min_precise(b).into()
+    }
+
+    simd_dispatch!(test(level) -> [f32; 4] = test_impl);
+    let wasm_result = test(Level::WasmSimd128(wasm32::WasmSimd128::new_unchecked()));
+
+    // Note: f32::NAN != f32::NAN hence we transmute to compare the bit pattern. In this case NaN
+    // bit pattern is preserved.
+    unsafe {
+        assert_eq!(
+            std::mem::transmute::<[f32; 4], [u32; 4]>(wasm_result),
+            std::mem::transmute::<[f32; 4], [u32; 4]>([1., f32::NAN, 7., f32::NEG_INFINITY]),
+            "Wasm did not match expected result."
+        );
     }
 }
 


### PR DESCRIPTION
> [!Note]
> Min/Max corner cases are target-specific and may change. If either argument is qNaN, x86 SIMD returns the second argument, Armv7 Neon returns NaN, Wasm is supposed to return NaN but does not always, but other targets actually uphold IEEE 754-2019 minimumNumber: returning the other argument if exactly one is qNaN, and NaN if both are.
> ~[Highway docs for Min/Max](https://github.com/google/highway/blob/0e759dd39119644c902eb0dcda2cfe03483c40ac/g3doc/quick_reference.md?plain=1#L702-L706)

Addresses issue https://github.com/raphlinus/fearless_simd/issues/20

### Before this change

vello_cpu with WASM SIMD tests had diffs like so:

<img width="965" alt="Screenshot 2025-06-27 at 4 13 47 pm" src="https://github.com/user-attachments/assets/25f5967d-588a-4fb4-8d4e-53a75097f695" />
<img width="1211" alt="Screenshot 2025-06-27 at 4 13 02 pm" src="https://github.com/user-attachments/assets/7301d4e8-3a87-48d4-b6c5-7a98bd62574c" />

### After this change

All vello_cpu WASM SIMD tests pass. (Note, I needed to manually test this as we don't automatically test vello_cpu on WASM SIMD. (Although I think we should consider it in the near term).

### Why?

This is basically explained by the comment https://github.com/raphlinus/fearless_simd/issues/20#issuecomment-3017811768

In vello_cpu we have the following code:

https://github.com/linebender/vello/blob/main/sparse_strips/vello_common/src/strip.rs#L327-L330

Inlined:

```rs
let line_px_left_y = line_top_y
  .madd(px_left_x - line_top_x, y_slope)
  .max_precise(ymin)
  .min_precise(ymax);
```

This code can multiply `f32::INFINITY` with `0` and result in `NaN`. The `max_precise` is used to massage `NaN` to `ymin`. In order to accomplish this we need to match Highway's semantics described in https://github.com/raphlinus/fearless_simd/issues/20#issuecomment-3017811768
.

Note, the three (neon, x86, WASM) implementations are not exactly the same in all situations, but for vello_common strip generation, they should all behave the same after this PR.



### Test plan

I used a `path` config in Cargo.toml from `vello` in order to test the `vello_cpu` wasm tests against this change. They went from all failing to all passing with `RUSTFLAGS=-Ctarget-feature=+simd128 wasm-pack test --chrome`.

I also added two very specific tests that enforce the NaN handling behavior of WASM in `max_precise` and `min_precise`.
