### PR TITLE
Add more features

### DIFF
--- a/fearless_simd/src/generated/fallback.rs
+++ b/fearless_simd/src/generated/fallback.rs
@@ -2307,6 +2307,16 @@ impl Simd for Fallback {
         }
     }
     #[inline(always)]
+    fn cvt_f32_u32x4(self, a: u32x4<Self>) -> f32x4<Self> {
+        [
+            a[0usize] as f32,
+            a[1usize] as f32,
+            a[2usize] as f32,
+            a[3usize] as f32,
+        ]
+        .simd_into(self)
+    }
+    #[inline(always)]
     fn splat_mask32x4(self, val: i32) -> mask32x4<Self> {
         [val; 4usize].simd_into(self)
     }
@@ -3503,6 +3513,11 @@ impl Simd for Fallback {
         self.combine_u8x16(self.reinterpret_u8_u32x4(a0), self.reinterpret_u8_u32x4(a1))
     }
     #[inline(always)]
+    fn cvt_f32_u32x8(self, a: u32x8<Self>) -> f32x8<Self> {
+        let (a0, a1) = self.split_u32x8(a);
+        self.combine_f32x4(self.cvt_f32_u32x4(a0), self.cvt_f32_u32x4(a1))
+    }
+    #[inline(always)]
     fn splat_mask32x8(self, a: i32) -> mask32x8<Self> {
         let half = self.splat_mask32x4(a);
         self.combine_mask32x4(half, half)
@@ -3731,6 +3746,36 @@ impl Simd for Fallback {
         b0.copy_from_slice(&a.val[0..8usize]);
         b1.copy_from_slice(&a.val[8usize..16usize]);
         (b0.simd_into(self), b1.simd_into(self))
+    }
+    #[inline(always)]
+    fn load_interleaved_128_f32x16(self, src: &[f32; 16usize]) -> f32x16<Self> {
+        [
+            src[0usize],
+            src[4usize],
+            src[8usize],
+            src[12usize],
+            src[1usize],
+            src[5usize],
+            src[9usize],
+            src[13usize],
+            src[2usize],
+            src[6usize],
+            src[10usize],
+            src[14usize],
+            src[3usize],
+            src[7usize],
+            src[11usize],
+            src[15usize],
+        ]
+        .simd_into(self)
+    }
+    #[inline(always)]
+    fn store_interleaved_128_f32x16(self, a: f32x16<Self>, dest: &mut [f32; 16usize]) -> () {
+        *dest = [
+            a[0usize], a[4usize], a[8usize], a[12usize], a[1usize], a[5usize], a[9usize],
+            a[13usize], a[2usize], a[6usize], a[10usize], a[14usize], a[3usize], a[7usize],
+            a[11usize], a[15usize],
+        ];
     }
     #[inline(always)]
     fn cvt_u32_f32x16(self, a: f32x16<Self>) -> u32x16<Self> {
@@ -4051,6 +4096,21 @@ impl Simd for Fallback {
             src[63usize],
         ]
         .simd_into(self)
+    }
+    #[inline(always)]
+    fn store_interleaved_128_u8x64(self, a: u8x64<Self>, dest: &mut [u8; 64usize]) -> () {
+        *dest = [
+            a[0usize], a[16usize], a[32usize], a[48usize], a[1usize], a[17usize], a[33usize],
+            a[49usize], a[2usize], a[18usize], a[34usize], a[50usize], a[3usize], a[19usize],
+            a[35usize], a[51usize], a[4usize], a[20usize], a[36usize], a[52usize], a[5usize],
+            a[21usize], a[37usize], a[53usize], a[6usize], a[22usize], a[38usize], a[54usize],
+            a[7usize], a[23usize], a[39usize], a[55usize], a[8usize], a[24usize], a[40usize],
+            a[56usize], a[9usize], a[25usize], a[41usize], a[57usize], a[10usize], a[26usize],
+            a[42usize], a[58usize], a[11usize], a[27usize], a[43usize], a[59usize], a[12usize],
+            a[28usize], a[44usize], a[60usize], a[13usize], a[29usize], a[45usize], a[61usize],
+            a[14usize], a[30usize], a[46usize], a[62usize], a[15usize], a[31usize], a[47usize],
+            a[63usize],
+        ];
     }
     #[inline(always)]
     fn splat_mask8x64(self, a: i8) -> mask8x64<Self> {
@@ -4402,6 +4462,16 @@ impl Simd for Fallback {
         .simd_into(self)
     }
     #[inline(always)]
+    fn store_interleaved_128_u16x32(self, a: u16x32<Self>, dest: &mut [u16; 32usize]) -> () {
+        *dest = [
+            a[0usize], a[8usize], a[16usize], a[24usize], a[1usize], a[9usize], a[17usize],
+            a[25usize], a[2usize], a[10usize], a[18usize], a[26usize], a[3usize], a[11usize],
+            a[19usize], a[27usize], a[4usize], a[12usize], a[20usize], a[28usize], a[5usize],
+            a[13usize], a[21usize], a[29usize], a[6usize], a[14usize], a[22usize], a[30usize],
+            a[7usize], a[15usize], a[23usize], a[31usize],
+        ];
+    }
+    #[inline(always)]
     fn narrow_u16x32(self, a: u16x32<Self>) -> u8x32<Self> {
         let (a0, a1) = self.split_u16x32(a);
         self.combine_u8x16(self.narrow_u16x16(a0), self.narrow_u16x16(a1))
@@ -4742,9 +4812,22 @@ impl Simd for Fallback {
         .simd_into(self)
     }
     #[inline(always)]
+    fn store_interleaved_128_u32x16(self, a: u32x16<Self>, dest: &mut [u32; 16usize]) -> () {
+        *dest = [
+            a[0usize], a[4usize], a[8usize], a[12usize], a[1usize], a[5usize], a[9usize],
+            a[13usize], a[2usize], a[6usize], a[10usize], a[14usize], a[3usize], a[7usize],
+            a[11usize], a[15usize],
+        ];
+    }
+    #[inline(always)]
     fn reinterpret_u8_u32x16(self, a: u32x16<Self>) -> u8x64<Self> {
         let (a0, a1) = self.split_u32x16(a);
         self.combine_u8x32(self.reinterpret_u8_u32x8(a0), self.reinterpret_u8_u32x8(a1))
+    }
+    #[inline(always)]
+    fn cvt_f32_u32x16(self, a: u32x16<Self>) -> f32x16<Self> {
+        let (a0, a1) = self.split_u32x16(a);
+        self.combine_f32x8(self.cvt_f32_u32x8(a0), self.cvt_f32_u32x8(a1))
     }
     #[inline(always)]
     fn splat_mask32x16(self, a: i32) -> mask32x16<Self> {

--- a/fearless_simd/src/generated/neon.rs
+++ b/fearless_simd/src/generated/neon.rs
@@ -169,7 +169,7 @@ impl Simd for Neon {
     }
     #[inline(always)]
     fn cvt_u32_f32x4(self, a: f32x4<Self>) -> u32x4<Self> {
-        unsafe { vcvtnq_u32_f32(a.into()).simd_into(self) }
+        unsafe { vcvtq_u32_f32(a.into()).simd_into(self) }
     }
     #[inline(always)]
     fn splat_i8x16(self, val: i8) -> i8x16<Self> {
@@ -800,6 +800,10 @@ impl Simd for Neon {
     #[inline(always)]
     fn reinterpret_u8_u32x4(self, a: u32x4<Self>) -> u8x16<Self> {
         unsafe { vreinterpretq_u8_u32(a.into()).simd_into(self) }
+    }
+    #[inline(always)]
+    fn cvt_f32_u32x4(self, a: u32x4<Self>) -> f32x4<Self> {
+        unsafe { vcvtq_f32_u32(a.into()).simd_into(self) }
     }
     #[inline(always)]
     fn splat_mask32x4(self, val: i32) -> mask32x4<Self> {
@@ -1949,6 +1953,11 @@ impl Simd for Neon {
         self.combine_u8x16(self.reinterpret_u8_u32x4(a0), self.reinterpret_u8_u32x4(a1))
     }
     #[inline(always)]
+    fn cvt_f32_u32x8(self, a: u32x8<Self>) -> f32x8<Self> {
+        let (a0, a1) = self.split_u32x8(a);
+        self.combine_f32x4(self.cvt_f32_u32x4(a0), self.cvt_f32_u32x4(a1))
+    }
+    #[inline(always)]
     fn splat_mask32x8(self, a: i32) -> mask32x8<Self> {
         let half = self.splat_mask32x4(a);
         self.combine_mask32x4(half, half)
@@ -2177,6 +2186,14 @@ impl Simd for Neon {
         b0.copy_from_slice(&a.val[0..8usize]);
         b1.copy_from_slice(&a.val[8usize..16usize]);
         (b0.simd_into(self), b1.simd_into(self))
+    }
+    #[inline(always)]
+    fn load_interleaved_128_f32x16(self, src: &[f32; 16usize]) -> f32x16<Self> {
+        unsafe { vld4q_f32(src.as_ptr()).simd_into(self) }
+    }
+    #[inline(always)]
+    fn store_interleaved_128_f32x16(self, a: f32x16<Self>, dest: &mut [f32; 16usize]) -> () {
+        unsafe { vst4q_f32(dest.as_mut_ptr(), a.into()) }
     }
     #[inline(always)]
     fn cvt_u32_f32x16(self, a: f32x16<Self>) -> u32x16<Self> {
@@ -2431,6 +2448,10 @@ impl Simd for Neon {
     #[inline(always)]
     fn load_interleaved_128_u8x64(self, src: &[u8; 64usize]) -> u8x64<Self> {
         unsafe { vld4q_u8(src.as_ptr()).simd_into(self) }
+    }
+    #[inline(always)]
+    fn store_interleaved_128_u8x64(self, a: u8x64<Self>, dest: &mut [u8; 64usize]) -> () {
+        unsafe { vst4q_u8(dest.as_mut_ptr(), a.into()) }
     }
     #[inline(always)]
     fn splat_mask8x64(self, a: i8) -> mask8x64<Self> {
@@ -2746,6 +2767,10 @@ impl Simd for Neon {
     #[inline(always)]
     fn load_interleaved_128_u16x32(self, src: &[u16; 32usize]) -> u16x32<Self> {
         unsafe { vld4q_u16(src.as_ptr()).simd_into(self) }
+    }
+    #[inline(always)]
+    fn store_interleaved_128_u16x32(self, a: u16x32<Self>, dest: &mut [u16; 32usize]) -> () {
+        unsafe { vst4q_u16(dest.as_mut_ptr(), a.into()) }
     }
     #[inline(always)]
     fn narrow_u16x32(self, a: u16x32<Self>) -> u8x32<Self> {
@@ -3070,9 +3095,18 @@ impl Simd for Neon {
         unsafe { vld4q_u32(src.as_ptr()).simd_into(self) }
     }
     #[inline(always)]
+    fn store_interleaved_128_u32x16(self, a: u32x16<Self>, dest: &mut [u32; 16usize]) -> () {
+        unsafe { vst4q_u32(dest.as_mut_ptr(), a.into()) }
+    }
+    #[inline(always)]
     fn reinterpret_u8_u32x16(self, a: u32x16<Self>) -> u8x64<Self> {
         let (a0, a1) = self.split_u32x16(a);
         self.combine_u8x32(self.reinterpret_u8_u32x8(a0), self.reinterpret_u8_u32x8(a1))
+    }
+    #[inline(always)]
+    fn cvt_f32_u32x16(self, a: u32x16<Self>) -> f32x16<Self> {
+        let (a0, a1) = self.split_u32x16(a);
+        self.combine_f32x8(self.cvt_f32_u32x8(a0), self.cvt_f32_u32x8(a1))
     }
     #[inline(always)]
     fn splat_mask32x16(self, a: i32) -> mask32x16<Self> {

--- a/fearless_simd/src/generated/simd_trait.rs
+++ b/fearless_simd/src/generated/simd_trait.rs
@@ -203,6 +203,7 @@ pub trait Simd: Sized + Clone + Copy + Send + Sync + Seal + 'static {
     fn max_u32x4(self, a: u32x4<Self>, b: u32x4<Self>) -> u32x4<Self>;
     fn combine_u32x4(self, a: u32x4<Self>, b: u32x4<Self>) -> u32x8<Self>;
     fn reinterpret_u8_u32x4(self, a: u32x4<Self>) -> u8x16<Self>;
+    fn cvt_f32_u32x4(self, a: u32x4<Self>) -> f32x4<Self>;
     fn splat_mask32x4(self, val: i32) -> mask32x4<Self>;
     fn not_mask32x4(self, a: mask32x4<Self>) -> mask32x4<Self>;
     fn and_mask32x4(self, a: mask32x4<Self>, b: mask32x4<Self>) -> mask32x4<Self>;
@@ -406,6 +407,7 @@ pub trait Simd: Sized + Clone + Copy + Send + Sync + Seal + 'static {
     fn combine_u32x8(self, a: u32x8<Self>, b: u32x8<Self>) -> u32x16<Self>;
     fn split_u32x8(self, a: u32x8<Self>) -> (u32x4<Self>, u32x4<Self>);
     fn reinterpret_u8_u32x8(self, a: u32x8<Self>) -> u8x32<Self>;
+    fn cvt_f32_u32x8(self, a: u32x8<Self>) -> f32x8<Self>;
     fn splat_mask32x8(self, val: i32) -> mask32x8<Self>;
     fn not_mask32x8(self, a: mask32x8<Self>) -> mask32x8<Self>;
     fn and_mask32x8(self, a: mask32x8<Self>, b: mask32x8<Self>) -> mask32x8<Self>;
@@ -447,6 +449,8 @@ pub trait Simd: Sized + Clone + Copy + Send + Sync + Seal + 'static {
     fn trunc_f32x16(self, a: f32x16<Self>) -> f32x16<Self>;
     fn select_f32x16(self, a: mask32x16<Self>, b: f32x16<Self>, c: f32x16<Self>) -> f32x16<Self>;
     fn split_f32x16(self, a: f32x16<Self>) -> (f32x8<Self>, f32x8<Self>);
+    fn load_interleaved_128_f32x16(self, src: &[f32; 16usize]) -> f32x16<Self>;
+    fn store_interleaved_128_f32x16(self, a: f32x16<Self>, dest: &mut [f32; 16usize]) -> ();
     fn cvt_u32_f32x16(self, a: f32x16<Self>) -> u32x16<Self>;
     fn splat_i8x64(self, val: i8) -> i8x64<Self>;
     fn not_i8x64(self, a: i8x64<Self>) -> i8x64<Self>;
@@ -490,6 +494,7 @@ pub trait Simd: Sized + Clone + Copy + Send + Sync + Seal + 'static {
     fn max_u8x64(self, a: u8x64<Self>, b: u8x64<Self>) -> u8x64<Self>;
     fn split_u8x64(self, a: u8x64<Self>) -> (u8x32<Self>, u8x32<Self>);
     fn load_interleaved_128_u8x64(self, src: &[u8; 64usize]) -> u8x64<Self>;
+    fn store_interleaved_128_u8x64(self, a: u8x64<Self>, dest: &mut [u8; 64usize]) -> ();
     fn splat_mask8x64(self, val: i8) -> mask8x64<Self>;
     fn not_mask8x64(self, a: mask8x64<Self>) -> mask8x64<Self>;
     fn and_mask8x64(self, a: mask8x64<Self>, b: mask8x64<Self>) -> mask8x64<Self>;
@@ -545,6 +550,7 @@ pub trait Simd: Sized + Clone + Copy + Send + Sync + Seal + 'static {
     fn max_u16x32(self, a: u16x32<Self>, b: u16x32<Self>) -> u16x32<Self>;
     fn split_u16x32(self, a: u16x32<Self>) -> (u16x16<Self>, u16x16<Self>);
     fn load_interleaved_128_u16x32(self, src: &[u16; 32usize]) -> u16x32<Self>;
+    fn store_interleaved_128_u16x32(self, a: u16x32<Self>, dest: &mut [u16; 32usize]) -> ();
     fn narrow_u16x32(self, a: u16x32<Self>) -> u8x32<Self>;
     fn reinterpret_u8_u16x32(self, a: u16x32<Self>) -> u8x64<Self>;
     fn splat_mask16x32(self, val: i16) -> mask16x32<Self>;
@@ -602,7 +608,9 @@ pub trait Simd: Sized + Clone + Copy + Send + Sync + Seal + 'static {
     fn max_u32x16(self, a: u32x16<Self>, b: u32x16<Self>) -> u32x16<Self>;
     fn split_u32x16(self, a: u32x16<Self>) -> (u32x8<Self>, u32x8<Self>);
     fn load_interleaved_128_u32x16(self, src: &[u32; 16usize]) -> u32x16<Self>;
+    fn store_interleaved_128_u32x16(self, a: u32x16<Self>, dest: &mut [u32; 16usize]) -> ();
     fn reinterpret_u8_u32x16(self, a: u32x16<Self>) -> u8x64<Self>;
+    fn cvt_f32_u32x16(self, a: u32x16<Self>) -> f32x16<Self>;
     fn splat_mask32x16(self, val: i32) -> mask32x16<Self>;
     fn not_mask32x16(self, a: mask32x16<Self>) -> mask32x16<Self>;
     fn and_mask32x16(self, a: mask32x16<Self>, b: mask32x16<Self>) -> mask32x16<Self>;

--- a/fearless_simd/src/generated/simd_types.rs
+++ b/fearless_simd/src/generated/simd_types.rs
@@ -1725,6 +1725,10 @@ impl<S: Simd> u32x4<S> {
     pub fn reinterpret_u8(self) -> u8x16<S> {
         self.simd.reinterpret_u8_u32x4(self)
     }
+    #[inline(always)]
+    pub fn cvt_f32(self) -> f32x4<S> {
+        self.simd.cvt_f32_u32x4(self)
+    }
 }
 impl<S: Simd> crate::SimdBase<u32, S> for u32x4<S> {
     const N: usize = 4;
@@ -3733,6 +3737,10 @@ impl<S: Simd> u32x8<S> {
     #[inline(always)]
     pub fn reinterpret_u8(self) -> u8x32<S> {
         self.simd.reinterpret_u8_u32x8(self)
+    }
+    #[inline(always)]
+    pub fn cvt_f32(self) -> f32x8<S> {
+        self.simd.cvt_f32_u32x8(self)
     }
 }
 impl<S: Simd> crate::SimdBase<u32, S> for u32x8<S> {
@@ -5891,6 +5899,10 @@ impl<S: Simd> u32x16<S> {
     #[inline(always)]
     pub fn reinterpret_u8(self) -> u8x64<S> {
         self.simd.reinterpret_u8_u32x16(self)
+    }
+    #[inline(always)]
+    pub fn cvt_f32(self) -> f32x16<S> {
+        self.simd.cvt_f32_u32x16(self)
     }
 }
 impl<S: Simd> crate::SimdBase<u32, S> for u32x16<S> {

--- a/fearless_simd/src/generated/wasm.rs
+++ b/fearless_simd/src/generated/wasm.rs
@@ -36,7 +36,6 @@ impl Simd for WasmSimd128 {
     }
     #[inline]
     fn vectorize<F: FnOnce() -> R, R>(self, f: F) -> R {
-        #[target_feature(enable = "simd128")]
         #[inline]
         unsafe fn vectorize_simd128<F: FnOnce() -> R, R>(f: F) -> R {
             f()

--- a/fearless_simd/src/generated/wasm.rs
+++ b/fearless_simd/src/generated/wasm.rs
@@ -36,6 +36,7 @@ impl Simd for WasmSimd128 {
     }
     #[inline]
     fn vectorize<F: FnOnce() -> R, R>(self, f: F) -> R {
+        #[target_feature(enable = "simd128")]
         #[inline]
         unsafe fn vectorize_simd128<F: FnOnce() -> R, R>(f: F) -> R {
             f()
@@ -764,6 +765,10 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn reinterpret_u8_u32x4(self, a: u32x4<Self>) -> u8x16<Self> {
+        todo!()
+    }
+    #[inline(always)]
+    fn cvt_f32_u32x4(self, a: u32x4<Self>) -> f32x4<Self> {
         todo!()
     }
     #[inline(always)]
@@ -1909,6 +1914,11 @@ impl Simd for WasmSimd128 {
         self.combine_u8x16(self.reinterpret_u8_u32x4(a0), self.reinterpret_u8_u32x4(a1))
     }
     #[inline(always)]
+    fn cvt_f32_u32x8(self, a: u32x8<Self>) -> f32x8<Self> {
+        let (a0, a1) = self.split_u32x8(a);
+        self.combine_f32x4(self.cvt_f32_u32x4(a0), self.cvt_f32_u32x4(a1))
+    }
+    #[inline(always)]
     fn splat_mask32x8(self, a: i32) -> mask32x8<Self> {
         let half = self.splat_mask32x4(a);
         self.combine_mask32x4(half, half)
@@ -2137,6 +2147,14 @@ impl Simd for WasmSimd128 {
         b0.copy_from_slice(&a.val[0..8usize]);
         b1.copy_from_slice(&a.val[8usize..16usize]);
         (b0.simd_into(self), b1.simd_into(self))
+    }
+    #[inline(always)]
+    fn load_interleaved_128_f32x16(self, src: &[f32; 16usize]) -> f32x16<Self> {
+        todo!()
+    }
+    #[inline(always)]
+    fn store_interleaved_128_f32x16(self, a: f32x16<Self>, dest: &mut [f32; 16usize]) -> () {
+        todo!()
     }
     #[inline(always)]
     fn cvt_u32_f32x16(self, a: f32x16<Self>) -> u32x16<Self> {
@@ -2390,6 +2408,10 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn load_interleaved_128_u8x64(self, src: &[u8; 64usize]) -> u8x64<Self> {
+        todo!()
+    }
+    #[inline(always)]
+    fn store_interleaved_128_u8x64(self, a: u8x64<Self>, dest: &mut [u8; 64usize]) -> () {
         todo!()
     }
     #[inline(always)]
@@ -2705,6 +2727,10 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn load_interleaved_128_u16x32(self, src: &[u16; 32usize]) -> u16x32<Self> {
+        todo!()
+    }
+    #[inline(always)]
+    fn store_interleaved_128_u16x32(self, a: u16x32<Self>, dest: &mut [u16; 32usize]) -> () {
         todo!()
     }
     #[inline(always)]
@@ -3029,9 +3055,18 @@ impl Simd for WasmSimd128 {
         todo!()
     }
     #[inline(always)]
+    fn store_interleaved_128_u32x16(self, a: u32x16<Self>, dest: &mut [u32; 16usize]) -> () {
+        todo!()
+    }
+    #[inline(always)]
     fn reinterpret_u8_u32x16(self, a: u32x16<Self>) -> u8x64<Self> {
         let (a0, a1) = self.split_u32x16(a);
         self.combine_u8x32(self.reinterpret_u8_u32x8(a0), self.reinterpret_u8_u32x8(a1))
+    }
+    #[inline(always)]
+    fn cvt_f32_u32x16(self, a: u32x16<Self>) -> f32x16<Self> {
+        let (a0, a1) = self.split_u32x16(a);
+        self.combine_f32x8(self.cvt_f32_u32x8(a0), self.cvt_f32_u32x8(a1))
     }
     #[inline(always)]
     fn splat_mask32x16(self, a: i32) -> mask32x16<Self> {

--- a/fearless_simd_gen/src/generic.rs
+++ b/fearless_simd_gen/src/generic.rs
@@ -224,6 +224,6 @@ pub fn generic_op(op: &str, sig: OpSig, ty: &VecType) -> TokenStream {
         }
         OpSig::Split => generic_split(ty),
         OpSig::Combine => generic_combine(ty),
-        OpSig::LoadInterleaved(_, _) => unimplemented!(),
+        OpSig::LoadInterleaved(_, _) | OpSig::StoreInterleaved(_, _) => unimplemented!(),
     }
 }

--- a/fearless_simd_gen/src/mk_fallback.rs
+++ b/fearless_simd_gen/src/mk_fallback.rs
@@ -5,7 +5,8 @@ use crate::arch::fallback::Fallback;
 use crate::arch::{Arch, fallback};
 use crate::generic::{generic_combine, generic_op, generic_split};
 use crate::ops::{
-    OpSig, TyFlavor, load_interleaved_arg_ty, ops_for_type, reinterpret_ty, valid_reinterpret,
+    OpSig, TyFlavor, load_interleaved_arg_ty, ops_for_type, reinterpret_ty,
+    store_interleaved_arg_ty, valid_reinterpret,
 };
 use crate::types::{SIMD_TYPES, ScalarType, VecType, type_imports};
 use proc_macro2::{Ident, Span, TokenStream};
@@ -94,7 +95,8 @@ fn mk_simd_impl() -> TokenStream {
         for (method, sig) in ops_for_type(vec_ty, true) {
             let b1 = (vec_ty.n_bits() > 128 && !matches!(method, "split" | "narrow"))
                 || vec_ty.n_bits() > 256;
-            let b2 = !matches!(method, "load_interleaved_128");
+            let b2 = !matches!(method, "load_interleaved_128")
+                && !matches!(method, "store_interleaved_128");
 
             if b1 && b2 {
                 methods.push(generic_op(method, sig, vec_ty));
@@ -329,25 +331,27 @@ fn mk_simd_impl() -> TokenStream {
                 }
                 OpSig::LoadInterleaved(block_size, count) => {
                     let len = (block_size * count) as usize / vec_ty.scalar_bits;
-                    let indices = {
-                        let indices = (0..len).collect::<Vec<_>>();
-                        interleave(&indices, len / count as usize)
-                    };
+                    let items = interleave_indices(len, count as usize, |idx| quote! { src[#idx] });
 
-                    let items = make_list(
-                        indices
-                            .into_iter()
-                            .map(|idx| {
-                                quote! { src[#idx] }
-                            })
-                            .collect::<Vec<_>>(),
-                    );
                     let arg = load_interleaved_arg_ty(block_size, count, vec_ty);
 
                     quote! {
                         #[inline(always)]
                         fn #method_ident(self, #arg) -> #ret_ty {
                             #items.simd_into(self)
+                        }
+                    }
+                }
+                OpSig::StoreInterleaved(block_size, count) => {
+                    let len = (block_size * count) as usize / vec_ty.scalar_bits;
+                    let items = interleave_indices(len, count as usize, |idx| quote! { a[#idx] });
+
+                    let arg = store_interleaved_arg_ty(block_size, count, vec_ty);
+
+                    quote! {
+                        #[inline(always)]
+                        fn #method_ident(self, #arg) -> #ret_ty {
+                            *dest = #items;
                         }
                     }
                 }
@@ -382,6 +386,19 @@ fn mk_simd_impl() -> TokenStream {
             #( #methods )*
         }
     }
+}
+
+fn interleave_indices(
+    len: usize,
+    count: usize,
+    func: impl FnMut(usize) -> TokenStream,
+) -> TokenStream {
+    let indices = {
+        let indices = (0..len).collect::<Vec<_>>();
+        interleave(&indices, len / count as usize)
+    };
+
+    make_list(indices.into_iter().map(func).collect::<Vec<_>>())
 }
 
 /// Whether the second argument of the function needs to be passed by reference.

--- a/fearless_simd_gen/src/mk_neon.rs
+++ b/fearless_simd_gen/src/mk_neon.rs
@@ -6,7 +6,9 @@ use quote::quote;
 use syn::Ident;
 
 use crate::arch::neon::split_intrinsic;
-use crate::ops::{load_interleaved_arg_ty, reinterpret_ty, valid_reinterpret};
+use crate::ops::{
+    load_interleaved_arg_ty, reinterpret_ty, store_interleaved_arg_ty, valid_reinterpret,
+};
 use crate::types::ScalarType;
 use crate::{
     arch::Arch,
@@ -82,7 +84,8 @@ fn mk_simd_impl(level: Level) -> TokenStream {
             let b1 = (vec_ty.n_bits() > 128 && !matches!(method, "split" | "narrow"))
                 || vec_ty.n_bits() > 256;
 
-            let b2 = !matches!(method, "load_interleaved_128");
+            let b2 = !matches!(method, "load_interleaved_128")
+                && !matches!(method, "store_interleaved_128");
 
             if b1 && b2 {
                 methods.push(generic_op(method, sig, vec_ty));
@@ -156,6 +159,27 @@ fn mk_simd_impl(level: Level) -> TokenStream {
                         fn #method_ident(self, #arg) -> #ret_ty {
                             unsafe {
                                 #intrinsic(src.as_ptr()).simd_into(self)
+                            }
+                        }
+                    }
+                }
+                OpSig::StoreInterleaved(block_size, count) => {
+                    let intrinsic = {
+                        // The function expects 64-bit or 128-bit
+                        let ty = VecType::new(
+                            vec_ty.scalar,
+                            vec_ty.scalar_bits,
+                            block_size as usize / vec_ty.scalar_bits,
+                        );
+                        simple_intrinsic("vst4", &ty)
+                    };
+                    let arg = store_interleaved_arg_ty(block_size, count, vec_ty);
+
+                    quote! {
+                        #[inline(always)]
+                        fn #method_ident(self, #arg) -> #ret_ty {
+                            unsafe {
+                                #intrinsic(dest.as_mut_ptr(), a.into())
                             }
                         }
                     }
@@ -310,7 +334,7 @@ fn mk_simd_impl(level: Level) -> TokenStream {
                 }
                 OpSig::Cvt(scalar, scalar_bits) => {
                     let to_ty = &VecType::new(scalar, scalar_bits, vec_ty.len);
-                    let neon = cvt_intrinsic("vcvtn", to_ty, vec_ty);
+                    let neon = cvt_intrinsic("vcvt", to_ty, vec_ty);
                     quote! {
                         #[inline(always)]
                         fn #method_ident(self, a: #ty<Self>) -> #ret_ty {

--- a/fearless_simd_gen/src/mk_wasm.rs
+++ b/fearless_simd_gen/src/mk_wasm.rs
@@ -273,7 +273,6 @@ fn mk_simd_impl(level: Level) -> TokenStream {
 
             #[inline]
             fn vectorize<F: FnOnce() -> R, R>(self, f: F) -> R {
-                #[target_feature(enable = "simd128")]
                 #[inline]
                 // unsafe not needed here with tf11, but can be justified
                 unsafe fn vectorize_simd128<F: FnOnce() -> R, R>(f: F) -> R {

--- a/fearless_simd_gen/src/mk_wasm.rs
+++ b/fearless_simd_gen/src/mk_wasm.rs
@@ -5,7 +5,7 @@ use proc_macro2::{Span, TokenStream};
 use quote::quote;
 use syn::Ident;
 
-use crate::ops::load_interleaved_arg_ty;
+use crate::ops::{load_interleaved_arg_ty, store_interleaved_arg_ty};
 use crate::{
     arch::{Arch, wasm::Wasm},
     generic::{generic_combine, generic_op, generic_split},
@@ -42,7 +42,8 @@ fn mk_simd_impl(level: Level) -> TokenStream {
 
         for (method, sig) in ops_for_type(vec_ty, true) {
             let b1 = vec_ty.n_bits() > 128 && !matches!(method, "split" | "narrow");
-            let b2 = !matches!(method, "load_interleaved_128");
+            let b2 = !matches!(method, "load_interleaved_128")
+                && !matches!(method, "store_interleaved_128");
 
             if b1 && b2 {
                 methods.push(generic_op(method, sig, vec_ty));
@@ -237,6 +238,15 @@ fn mk_simd_impl(level: Level) -> TokenStream {
                         }
                     }
                 }
+                OpSig::StoreInterleaved(block_size, count) => {
+                    let arg = store_interleaved_arg_ty(block_size, count, vec_ty);
+                    quote! {
+                        #[inline(always)]
+                        fn #method_ident(self, #arg) -> #ret_ty {
+                            todo!()
+                        }
+                    }
+                }
             };
 
             methods.push(m);
@@ -263,6 +273,7 @@ fn mk_simd_impl(level: Level) -> TokenStream {
 
             #[inline]
             fn vectorize<F: FnOnce() -> R, R>(self, f: F) -> R {
+                #[target_feature(enable = "simd128")]
                 #[inline]
                 // unsafe not needed here with tf11, but can be justified
                 unsafe fn vectorize_simd128<F: FnOnce() -> R, R>(f: F) -> R {


### PR DESCRIPTION
This PR adds the following methods:
- Convert from u32 to f32.
- Interleaved loading for f32.
- Interleaved storing for various types.
- Fixes a bug where for neon, we used `vcvtnq_u32_f32`, which does conversion while rounding to nearest, instead of `vcvtq_u32_f32`, which has the same truncating as scalar. I guess the question here is which one should be the default, but for `vello_cpu` we at least need the truncating behavior.