### PR TITLE
[wasm] Add copysign, select, shr, reinterpret, and cvt

### DIFF
--- a/fearless_simd/src/generated/wasm.rs
+++ b/fearless_simd/src/generated/wasm.rs
@@ -76,8 +76,10 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn copysign_f32x4(self, a: f32x4<Self>, b: f32x4<Self>) -> f32x4<Self> {
-        /// TODO: copysign
-        todo!()
+        let sign_mask = f32x4_splat(-0.0_f32);
+        let sign_bits = v128_and(b.into(), sign_mask.into());
+        let magnitude = v128_andnot(a.into(), sign_mask.into());
+        v128_or(magnitude, sign_bits).simd_into(self)
     }
     #[inline(always)]
     fn simd_eq_f32x4(self, a: f32x4<Self>, b: f32x4<Self>) -> mask32x4<Self> {
@@ -145,7 +147,7 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn select_f32x4(self, a: mask32x4<Self>, b: f32x4<Self>, c: f32x4<Self>) -> f32x4<Self> {
-        todo!()
+        v128_bitselect(b.into(), c.into(), a.into()).simd_into(self)
     }
     #[inline(always)]
     fn combine_f32x4(self, a: f32x4<Self>, b: f32x4<Self>) -> f32x8<Self> {
@@ -156,7 +158,7 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn cvt_u32_f32x4(self, a: f32x4<Self>) -> u32x4<Self> {
-        todo!()
+        u32x4_trunc_sat_f32x4(a.into()).simd_into(self)
     }
     #[inline(always)]
     fn splat_i8x16(self, val: i8) -> i8x16<Self> {
@@ -195,7 +197,7 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn shr_i8x16(self, a: i8x16<Self>, shift: u32) -> i8x16<Self> {
-        todo!()
+        i8x16_shr(a.into(), shift).simd_into(self)
     }
     #[inline(always)]
     fn simd_eq_i8x16(self, a: i8x16<Self>, b: i8x16<Self>) -> mask8x16<Self> {
@@ -232,7 +234,7 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn select_i8x16(self, a: mask8x16<Self>, b: i8x16<Self>, c: i8x16<Self>) -> i8x16<Self> {
-        todo!()
+        v128_bitselect(b.into(), c.into(), a.into()).simd_into(self)
     }
     #[inline(always)]
     fn min_i8x16(self, a: i8x16<Self>, b: i8x16<Self>) -> i8x16<Self> {
@@ -251,7 +253,7 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn reinterpret_u8_i8x16(self, a: i8x16<Self>) -> u8x16<Self> {
-        todo!()
+        <v128>::from(a).simd_into(self)
     }
     #[inline(always)]
     fn splat_u8x16(self, val: u8) -> u8x16<Self> {
@@ -290,7 +292,7 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn shr_u8x16(self, a: u8x16<Self>, shift: u32) -> u8x16<Self> {
-        todo!()
+        u8x16_shr(a.into(), shift).simd_into(self)
     }
     #[inline(always)]
     fn simd_eq_u8x16(self, a: u8x16<Self>, b: u8x16<Self>) -> mask8x16<Self> {
@@ -327,7 +329,7 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn select_u8x16(self, a: mask8x16<Self>, b: u8x16<Self>, c: u8x16<Self>) -> u8x16<Self> {
-        todo!()
+        v128_bitselect(b.into(), c.into(), a.into()).simd_into(self)
     }
     #[inline(always)]
     fn min_u8x16(self, a: u8x16<Self>, b: u8x16<Self>) -> u8x16<Self> {
@@ -375,7 +377,7 @@ impl Simd for WasmSimd128 {
         b: mask8x16<Self>,
         c: mask8x16<Self>,
     ) -> mask8x16<Self> {
-        todo!()
+        v128_bitselect(b.into(), c.into(), a.into()).simd_into(self)
     }
     #[inline(always)]
     fn simd_eq_mask8x16(self, a: mask8x16<Self>, b: mask8x16<Self>) -> mask8x16<Self> {
@@ -422,7 +424,7 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn shr_i16x8(self, a: i16x8<Self>, shift: u32) -> i16x8<Self> {
-        todo!()
+        i16x8_shr(a.into(), shift).simd_into(self)
     }
     #[inline(always)]
     fn simd_eq_i16x8(self, a: i16x8<Self>, b: i16x8<Self>) -> mask16x8<Self> {
@@ -454,7 +456,7 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn select_i16x8(self, a: mask16x8<Self>, b: i16x8<Self>, c: i16x8<Self>) -> i16x8<Self> {
-        todo!()
+        v128_bitselect(b.into(), c.into(), a.into()).simd_into(self)
     }
     #[inline(always)]
     fn min_i16x8(self, a: i16x8<Self>, b: i16x8<Self>) -> i16x8<Self> {
@@ -473,7 +475,7 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn reinterpret_u8_i16x8(self, a: i16x8<Self>) -> u8x16<Self> {
-        todo!()
+        <v128>::from(a).simd_into(self)
     }
     #[inline(always)]
     fn splat_u16x8(self, val: u16) -> u16x8<Self> {
@@ -509,7 +511,7 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn shr_u16x8(self, a: u16x8<Self>, shift: u32) -> u16x8<Self> {
-        todo!()
+        u16x8_shr(a.into(), shift).simd_into(self)
     }
     #[inline(always)]
     fn simd_eq_u16x8(self, a: u16x8<Self>, b: u16x8<Self>) -> mask16x8<Self> {
@@ -541,7 +543,7 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn select_u16x8(self, a: mask16x8<Self>, b: u16x8<Self>, c: u16x8<Self>) -> u16x8<Self> {
-        todo!()
+        v128_bitselect(b.into(), c.into(), a.into()).simd_into(self)
     }
     #[inline(always)]
     fn min_u16x8(self, a: u16x8<Self>, b: u16x8<Self>) -> u16x8<Self> {
@@ -560,7 +562,7 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn reinterpret_u8_u16x8(self, a: u16x8<Self>) -> u8x16<Self> {
-        todo!()
+        <v128>::from(a).simd_into(self)
     }
     #[inline(always)]
     fn splat_mask16x8(self, val: i16) -> mask16x8<Self> {
@@ -589,7 +591,7 @@ impl Simd for WasmSimd128 {
         b: mask16x8<Self>,
         c: mask16x8<Self>,
     ) -> mask16x8<Self> {
-        todo!()
+        v128_bitselect(b.into(), c.into(), a.into()).simd_into(self)
     }
     #[inline(always)]
     fn simd_eq_mask16x8(self, a: mask16x8<Self>, b: mask16x8<Self>) -> mask16x8<Self> {
@@ -636,7 +638,7 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn shr_i32x4(self, a: i32x4<Self>, shift: u32) -> i32x4<Self> {
-        todo!()
+        i32x4_shr(a.into(), shift).simd_into(self)
     }
     #[inline(always)]
     fn simd_eq_i32x4(self, a: i32x4<Self>, b: i32x4<Self>) -> mask32x4<Self> {
@@ -668,7 +670,7 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn select_i32x4(self, a: mask32x4<Self>, b: i32x4<Self>, c: i32x4<Self>) -> i32x4<Self> {
-        todo!()
+        v128_bitselect(b.into(), c.into(), a.into()).simd_into(self)
     }
     #[inline(always)]
     fn min_i32x4(self, a: i32x4<Self>, b: i32x4<Self>) -> i32x4<Self> {
@@ -687,7 +689,7 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn reinterpret_u8_i32x4(self, a: i32x4<Self>) -> u8x16<Self> {
-        todo!()
+        <v128>::from(a).simd_into(self)
     }
     #[inline(always)]
     fn splat_u32x4(self, val: u32) -> u32x4<Self> {
@@ -723,7 +725,7 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn shr_u32x4(self, a: u32x4<Self>, shift: u32) -> u32x4<Self> {
-        todo!()
+        u32x4_shr(a.into(), shift).simd_into(self)
     }
     #[inline(always)]
     fn simd_eq_u32x4(self, a: u32x4<Self>, b: u32x4<Self>) -> mask32x4<Self> {
@@ -755,7 +757,7 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn select_u32x4(self, a: mask32x4<Self>, b: u32x4<Self>, c: u32x4<Self>) -> u32x4<Self> {
-        todo!()
+        v128_bitselect(b.into(), c.into(), a.into()).simd_into(self)
     }
     #[inline(always)]
     fn min_u32x4(self, a: u32x4<Self>, b: u32x4<Self>) -> u32x4<Self> {
@@ -774,11 +776,11 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn reinterpret_u8_u32x4(self, a: u32x4<Self>) -> u8x16<Self> {
-        todo!()
+        <v128>::from(a).simd_into(self)
     }
     #[inline(always)]
     fn cvt_f32_u32x4(self, a: u32x4<Self>) -> f32x4<Self> {
-        todo!()
+        f32x4_convert_u32x4(a.into()).simd_into(self)
     }
     #[inline(always)]
     fn splat_mask32x4(self, val: i32) -> mask32x4<Self> {
@@ -807,7 +809,7 @@ impl Simd for WasmSimd128 {
         b: mask32x4<Self>,
         c: mask32x4<Self>,
     ) -> mask32x4<Self> {
-        todo!()
+        v128_bitselect(b.into(), c.into(), a.into()).simd_into(self)
     }
     #[inline(always)]
     fn simd_eq_mask32x4(self, a: mask32x4<Self>, b: mask32x4<Self>) -> mask32x4<Self> {
@@ -2159,7 +2161,21 @@ impl Simd for WasmSimd128 {
     }
     #[inline(always)]
     fn load_interleaved_128_f32x16(self, src: &[f32; 16usize]) -> f32x16<Self> {
-        todo!()
+        let v0: v128 = unsafe { v128_load(src[0 * 4usize..].as_ptr() as *const v128) };
+        let v1: v128 = unsafe { v128_load(src[1 * 4usize..].as_ptr() as *const v128) };
+        let v2: v128 = unsafe { v128_load(src[2 * 4usize..].as_ptr() as *const v128) };
+        let v3: v128 = unsafe { v128_load(src[3 * 4usize..].as_ptr() as *const v128) };
+        let v02_lower = u32x4_shuffle::<0, 4, 1, 5>(v0, v2);
+        let v13_lower = u32x4_shuffle::<0, 4, 1, 5>(v1, v3);
+        let v02_upper = u32x4_shuffle::<2, 6, 3, 7>(v0, v2);
+        let v13_upper = u32x4_shuffle::<2, 6, 3, 7>(v1, v3);
+        let out0 = u32x4_shuffle::<0, 4, 1, 5>(v02_lower, v13_lower);
+        let out1 = u32x4_shuffle::<2, 6, 3, 7>(v02_lower, v13_lower);
+        let out2 = u32x4_shuffle::<0, 4, 1, 5>(v02_upper, v13_upper);
+        let out3 = u32x4_shuffle::<2, 6, 3, 7>(v02_upper, v13_upper);
+        let combined_lower = self.combine_f32x4(out0.simd_into(self), out1.simd_into(self));
+        let combined_upper = self.combine_f32x4(out2.simd_into(self), out3.simd_into(self));
+        self.combine_f32x8(combined_lower, combined_upper)
     }
     #[inline(always)]
     fn store_interleaved_128_f32x16(self, a: f32x16<Self>, dest: &mut [f32; 16usize]) -> () {

--- a/fearless_simd_tests/tests/wasm.rs
+++ b/fearless_simd_tests/tests/wasm.rs
@@ -125,6 +125,16 @@ test_wasm_simd_parity! {
 }
 
 test_wasm_simd_parity! {
+    fn copysign_f32x4() {
+        |s| -> [f32; 4] {
+            let a = f32x4::from_slice(s, &[1.0, -2.0, -3.0, 4.0]);
+            let b = f32x4::from_slice(s, &[-1.0, 1.0, -1.0, 1.0]);
+            a.copysign(b).into()
+        }
+    }
+}
+
+test_wasm_simd_parity! {
     fn simd_eq_f32x4() {
         |s| -> [i32; 4] {
             let a = f32x4::from_slice(s, &[4.0, 2.0, 1.0, 0.0]);
@@ -328,6 +338,34 @@ test_wasm_simd_parity! {
             let a = f32x4::from_slice(s, &[1.0, 2.0, 3.0, 4.0]);
             let b = f32x4::from_slice(s, &[5.0, 6.0, 7.0, 8.0]);
             a.combine(b).into()
+        }
+    }
+}
+
+test_wasm_simd_parity! {
+    fn cvt_u32_f32x4() {
+        |s| -> [u32; 4] {
+            let a = f32x4::from_slice(s, &[
+                -1.0,
+                42.7,
+                5e9,
+                f32::NAN,
+            ]);
+            a.cvt_u32().into()
+        }
+    }
+}
+
+test_wasm_simd_parity! {
+    fn cvt_f32_u32x4() {
+        |s| -> [f32; 4] {
+            let a = u32x4::from_slice(s, &[
+                0,
+                42,
+                1000000,
+                u32::MAX,
+            ]);
+            a.cvt_f32().into()
         }
     }
 }
@@ -634,6 +672,199 @@ test_wasm_simd_parity! {
             let a = u32x4::from_slice(s, &[0, 1, 2, 3]);
             let b = u32x4::from_slice(s, &[4, 5, 6, 7]);
             s.zip_high_u32x4(a, b).into()
+        }
+    }
+}
+
+// Right Shift
+
+test_wasm_simd_parity! {
+    fn shr_i8x16() {
+        |s| -> [i8; 16] {
+            let a = i8x16::from_slice(s, &[
+                -128, -64, -32, -16, -8, -4, -2, -1,
+                127, 64, 32, 16, 8, 4, 2, 1
+            ]);
+            a.shr(2).into()
+        }
+    }
+}
+
+test_wasm_simd_parity! {
+    fn shr_u8x16() {
+        |s| -> [u8; 16] {
+            let a = u8x16::from_slice(s, &[
+                255, 128, 64, 32, 16, 8, 4, 2,
+                254, 127, 63, 31, 15, 7, 3, 1
+            ]);
+            a.shr(2).into()
+        }
+    }
+}
+
+test_wasm_simd_parity! {
+    fn shr_i16x8() {
+        |s| -> [i16; 8] {
+            let a = i16x8::from_slice(s, &[
+                -32768, -16384, -1024, -1,
+                32767, 16384, 1024, 1
+            ]);
+            a.shr(4).into()
+        }
+    }
+}
+
+test_wasm_simd_parity! {
+    fn shr_u16x8() {
+        |s| -> [u16; 8] {
+            let a = u16x8::from_slice(s, &[
+                65535, 32768, 16384, 8192,
+                4096, 2048, 1024, 512
+            ]);
+            a.shr(4).into()
+        }
+    }
+}
+
+test_wasm_simd_parity! {
+    fn shr_i32x4() {
+        |s| -> [i32; 4] {
+            let a = i32x4::from_slice(s, &[
+                i32::MIN,
+                -65536,
+                65536,
+                i32::MAX
+            ]);
+            a.shr(8).into()
+        }
+    }
+}
+
+test_wasm_simd_parity! {
+    fn shr_u32x4() {
+        |s| -> [u32; 4] {
+            let a = u32x4::from_slice(s, &[
+                u32::MAX,
+                2147483648,
+                65536,
+                256
+            ]);
+            a.shr(8).into()
+        }
+    }
+}
+
+// Select
+
+test_wasm_simd_parity! {
+    fn select_f32x4() {
+        |s| -> [f32; 4] {
+            let mask = mask32x4::from_slice(s, &[-1, 0, -1, 0]);
+            let b = f32x4::from_slice(s, &[1.0, 2.0, 3.0, 4.0]);
+            let c = f32x4::from_slice(s, &[5.0, 6.0, 7.0, 8.0]);
+            mask.select(b, c).into()
+        }
+    }
+}
+
+test_wasm_simd_parity! {
+    fn select_i8x16() {
+        |s| -> [i8; 16] {
+            let mask = mask8x16::from_slice(s, &[-1, 0, -1, 0, -1, 0, -1, 0, -1, 0, -1, 0, -1, 0, -1, 0]);
+            let b = i8x16::from_slice(s, &[10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120, -10, -20, -30, -40]);
+            let c = i8x16::from_slice(s, &[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, -1, -2, -3, -4]);
+            mask.select(b, c).into()
+        }
+    }
+}
+
+test_wasm_simd_parity! {
+    fn select_u8x16() {
+        |s| -> [u8; 16] {
+            let mask = mask8x16::from_slice(s, &[0, -1, 0, -1, 0, -1, 0, -1, 0, -1, 0, -1, 0, -1, 0, -1]);
+            let b = u8x16::from_slice(s, &[10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120, 130, 140, 150, 160]);
+            let c = u8x16::from_slice(s, &[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]);
+            mask.select(b, c).into()
+        }
+    }
+}
+
+test_wasm_simd_parity! {
+    fn select_mask8x16() {
+        |s| -> [i8; 16] {
+            let mask = mask8x16::from_slice(s, &[-1, -1, 0, 0, -1, -1, 0, 0, -1, -1, 0, 0, -1, -1, 0, 0]);
+            let b = mask8x16::from_slice(s, &[-1, 0, -1, 0, -1, 0, -1, 0, -1, 0, -1, 0, -1, 0, -1, 0]);
+            let c = mask8x16::from_slice(s, &[0, -1, 0, -1, -1, -1, 0, -1, 0, -1, 0, -1, 0, -1, 0, -1]);
+            let result: mask8x16<_> = mask.select(b, c);
+            result.into()
+        }
+    }
+}
+
+test_wasm_simd_parity! {
+    fn select_i16x8() {
+        |s| -> [i16; 8] {
+            let mask = mask16x8::from_slice(s, &[-1, 0, -1, 0, -1, 0, -1, 0]);
+            let b = i16x8::from_slice(s, &[100, 200, 300, 400, -100, -200, -300, -400]);
+            let c = i16x8::from_slice(s, &[10, 20, 30, 40, -10, -20, -30, -40]);
+            mask.select(b, c).into()
+        }
+    }
+}
+
+test_wasm_simd_parity! {
+    fn select_u16x8() {
+        |s| -> [u16; 8] {
+            let mask = mask16x8::from_slice(s, &[0, -1, 0, -1, 0, -1, 0, -1]);
+            let b = u16x8::from_slice(s, &[1000, 2000, 3000, 4000, 5000, 6000, 7000, 8000]);
+            let c = u16x8::from_slice(s, &[100, 200, 300, 400, 500, 600, 700, 800]);
+            mask.select(b, c).into()
+        }
+    }
+}
+
+test_wasm_simd_parity! {
+    fn select_mask16x8() {
+        |s| -> [i16; 8] {
+            let mask = mask16x8::from_slice(s, &[-1, -1, 0, 0, -1, -1, 0, 0]);
+            let b = mask16x8::from_slice(s, &[-1, 0, -1, 0, -1, 0, -1, 0]);
+            let c = mask16x8::from_slice(s, &[0, -1, 0, -1, 0, -1, 0, -1]);
+            let result: mask16x8<_> = mask.select(b, c);
+            result.into()
+        }
+    }
+}
+
+test_wasm_simd_parity! {
+    fn select_i32x4() {
+        |s| -> [i32; 4] {
+            let mask = mask32x4::from_slice(s, &[-1, 0, 0, -1]);
+            let b = i32x4::from_slice(s, &[10000, 20000, -30000, -40000]);
+            let c = i32x4::from_slice(s, &[100, 200, -300, -400]);
+            mask.select(b, c).into()
+        }
+    }
+}
+
+test_wasm_simd_parity! {
+    fn select_u32x4() {
+        |s| -> [u32; 4] {
+            let mask = mask32x4::from_slice(s, &[0, -1, -1, 0]);
+            let b = u32x4::from_slice(s, &[100000, 200000, 300000, 400000]);
+            let c = u32x4::from_slice(s, &[1000, 2000, 3000, 4000]);
+            mask.select(b, c).into()
+        }
+    }
+}
+
+test_wasm_simd_parity! {
+    fn select_mask32x4() {
+        |s| -> [i32; 4] {
+            let mask = mask32x4::from_slice(s, &[-1, 0, -1, 0]);
+            let b = mask32x4::from_slice(s, &[-1, -1, 0, 0]);
+            let c = mask32x4::from_slice(s, &[0, 0, -1, -1]);
+            let result: mask32x4<_> = mask.select(b, c);
+            result.into()
         }
     }
 }


### PR DESCRIPTION
### Context

Add a bunch of operations to wasm32 architecture. This is actually enough to run the vello_cpu SIMD demo.

### Test plan

I unit tested, but I also tested against https://github.com/linebender/vello/pull/1078

### Results

TODO